### PR TITLE
fix: diagnose custom providers unsupported by upstream TUI

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -90,6 +90,8 @@ considers a direct API key configured only when it is stored under provider ID
 `zai` or `bigmodel`. An arbitrary provider ID is valid model configuration,
 but as the only provider it still triggers the upstream login gate. The
 display name, API format, endpoint, headers and models remain fully custom.
+The launcher detects this mismatch before opening the TUI and prints the
+required provider IDs instead of reporting the configuration as fully ready.
 
 For an Anthropic-compatible endpoint:
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -13,7 +13,11 @@ import { constants as osConstants, homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { ensureUserConfig, readConfiguredModelAccess } from "./model-access.ts";
+import {
+  ensureUserConfig,
+  readConfiguredModelAccess,
+  type ConfiguredModelAccess
+} from "./model-access.ts";
 import {
   classifyZaiOAuthInvocation,
   runZaiOAuthLogin,
@@ -106,6 +110,15 @@ export function normalizeLoginArgs(args: string[]): { args: string[]; checkConfi
     return { args: args.filter((argument) => argument !== "--oauth"), checkConfiguredAccess: false };
   }
   return { args, checkConfiguredAccess: false };
+}
+
+export function formatUnsupportedTuiProviderMessage(access: ConfiguredModelAccess): string {
+  return [
+    `Model access is configured for headless use as ${access.model}, but the upstream TUI`,
+    'requires a direct API key under provider ID "zai" or "bigmodel".',
+    `Rename the provider key and update model.main/model.lite in ${access.configPath}.`,
+    "See docs/CONFIGURATION.md for a compatible custom-provider example."
+  ].join("\n");
 }
 
 function longOptionName(argument: string): string {
@@ -433,16 +446,25 @@ export async function main(args: string[]): Promise<number> {
 
   const login = normalizeLoginArgs(args);
   const zaiOAuth = classifyZaiOAuthInvocation(args);
+  const configuredAccess = await readConfiguredModelAccess();
   if (login.checkConfiguredAccess) {
-    const access = await readConfiguredModelAccess();
-    if (access) {
+    if (configuredAccess?.tuiCompatible) {
       console.log(
-        `Model access is already configured for ${access.model}; OAuth login is not required.\n`
-        + `Config: ${access.configPath}\n`
+        `Model access is already configured for ${configuredAccess.model}; OAuth login is not required.\n`
+        + `Config: ${configuredAccess.configPath}\n`
         + "Run `zcode login --oauth` to force Z.AI OAuth."
       );
       return 0;
     }
+    if (configuredAccess) {
+      console.error(formatUnsupportedTuiProviderMessage(configuredAccess));
+      return 1;
+    }
+  }
+
+  if (isTuiRuntimeInvocation(login.args) && configuredAccess && !configuredAccess.tuiCompatible) {
+    console.error(formatUnsupportedTuiProviderMessage(configuredAccess));
+    return 1;
   }
 
   if (zaiOAuth) {

--- a/src/model-access.ts
+++ b/src/model-access.ts
@@ -23,6 +23,7 @@ export interface ConfiguredModelAccess {
   configPath: string;
   model: string;
   providerId: string;
+  tuiCompatible: boolean;
 }
 
 export interface UserConfigBootstrapResult {
@@ -31,6 +32,12 @@ export interface UserConfigBootstrapResult {
 }
 
 export type UserConfigRecord = Record<string, unknown>;
+
+const tuiDirectApiKeyProviderIds = new Set(["zai", "bigmodel"]);
+
+export function isTuiCompatibleProviderId(providerId: string): boolean {
+  return tuiDirectApiKeyProviderIds.has(providerId);
+}
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
@@ -183,5 +190,10 @@ export async function readConfiguredModelAccess(
   const provider = config.provider?.[providerId];
   const apiKey = provider?.options?.apiKey;
   if (!provider?.models?.[modelId] || typeof apiKey !== "string" || !apiKey.trim()) return null;
-  return { configPath, model, providerId };
+  return {
+    configPath,
+    model,
+    providerId,
+    tuiCompatible: isTuiCompatibleProviderId(providerId)
+  };
 }

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 import {
   formatVersionOutput,
+  formatUnsupportedTuiProviderMessage,
   isTuiRuntimeInvocation,
   isVersionInvocation,
   normalizeLoginArgs,
@@ -14,6 +15,7 @@ import {
   resolveModelRetryMaxRetries,
   withDefaultBrowserUse
 } from "../src/launcher.ts";
+import type { ConfiguredModelAccess } from "../src/model-access.ts";
 import { classifyZaiOAuthInvocation } from "../src/zai-oauth.ts";
 
 describe("launcher routing", () => {
@@ -70,6 +72,21 @@ describe("launcher routing", () => {
       args: ["login", "--no-browser"],
       checkConfiguredAccess: false
     });
+  });
+
+  test("explains when configured headless access cannot pass the upstream TUI gate", () => {
+    const access: ConfiguredModelAccess = {
+      configPath: "/home/user/.zcode/cli/config.json",
+      model: "custom/GLM-5.3",
+      providerId: "custom",
+      tuiCompatible: false
+    };
+
+    expect(formatUnsupportedTuiProviderMessage(access)).toContain(
+      'provider ID "zai" or "bigmodel"'
+    );
+    expect(formatUnsupportedTuiProviderMessage(access)).toContain(access.configPath);
+    expect(formatUnsupportedTuiProviderMessage(access)).not.toContain("configured-key");
   });
 
   test("enables Browser Use only for agent-producing runtime invocations", () => {

--- a/test/model-access.test.ts
+++ b/test/model-access.test.ts
@@ -38,7 +38,31 @@ describe("configured model access", () => {
     expect(await readConfiguredModelAccess(env)).toEqual({
       configPath: path,
       model: "zai/custom/model",
-      providerId: "zai"
+      providerId: "zai",
+      tuiCompatible: true
+    });
+  });
+
+  test("reports custom provider ids as headless-only for the upstream TUI gate", async () => {
+    const home = await temporaryHome();
+    const env = { HOME: home, USERPROFILE: home };
+    const path = userConfigPath(env);
+    await mkdir(join(home, ".zcode", "cli"), { recursive: true });
+    await writeFile(path, JSON.stringify({
+      provider: {
+        "bigmodel-coding-plan": {
+          options: { apiKey: "configured-key" },
+          models: { "GLM-5.3": { name: "GLM-5.3" } }
+        }
+      },
+      model: { main: "bigmodel-coding-plan/GLM-5.3" }
+    }));
+
+    expect(await readConfiguredModelAccess(env)).toEqual({
+      configPath: path,
+      model: "bigmodel-coding-plan/GLM-5.3",
+      providerId: "bigmodel-coding-plan",
+      tuiCompatible: false
     });
   });
 


### PR DESCRIPTION
## Summary

- distinguish configured headless model access from provider IDs accepted by the upstream TUI login gate
- fail early with an actionable `zai` / `bigmodel` provider-ID diagnostic instead of opening a TUI that reports no model access
- document the compatibility constraint and cover both compatible and custom provider configurations

## Why

A valid custom provider can run `zcode --prompt`, while the upstream interactive TUI still rejects it because its direct-key gate only recognizes `zai` and `bigmodel`. The launcher previously treated both capabilities as equivalent, which made integrations believe an interactive worker was ready when it was not.

This change does not hard-code a release version and does not expose API keys.

## Verification

- `npx --yes bun run typecheck`
- full suite: 491 passed; one unrelated 5s rich-Markdown performance test timed out at 5.17s
- isolated rerun: `npx --yes bun test test/code-highlighter.test.ts --timeout 10000` (16 passed)
- all launcher/runtime integration failures pass after `npx --yes bun run sync:local`