### PR TITLE
fix(tui): keep model switching session-only

### DIFF
--- a/packages/zcode-tui/src/index.ts
+++ b/packages/zcode-tui/src/index.ts
@@ -6,6 +6,7 @@ import {
   clearSetupPending,
   readConfiguredModelAccess,
   readSetupPending,
+  readUserConfig,
   updateUserConfig,
   userConfigPathHint
 } from "../../../src/model-access.ts";
@@ -125,6 +126,7 @@ import {
 } from "./notifications.ts";
 import {
   effortPicker,
+  explicitModelRequest,
   isEffortPickerRequest,
   isModelPickerRequest,
   modelPicker,
@@ -186,6 +188,7 @@ import {
   appliesToSetting,
   nextMode,
   nextPickerCommand,
+  nextPickerValue,
   normalizedMode,
   settingTargetForCommand,
   transcriptPageDirection,
@@ -1071,6 +1074,14 @@ class ZCodeTui {
       return;
     }
     if (isModelPickerRequest(input) && await this.showModelPicker()) {
+      return;
+    }
+    // Explicit `/model <provider/model>` is also a session-only switch — the
+    // runtime's plain /model command would persist model.main.
+    const explicitModel = explicitModelRequest(input);
+    if (explicitModel) {
+      this.addUserMessage(submission.displayInput);
+      await this.switchTransientModel(explicitModel);
       return;
     }
     if (isEffortPickerRequest(input) && await this.showCommandPicker(
@@ -2888,39 +2899,129 @@ class ZCodeTui {
   }
 
   /**
-   * Three-level cascade: provider → main model → lite model.
-   * Esc at any sub-level returns to the previous level; Esc at the provider
-   * level exits /model. The selection persists to config.json (model.main +
-   * model.lite) and also applies the main model to the current session via
-   * `/model <provider/model>`.
+   * Refresh modelOptions from the bridge. After a fresh login
+   * (loginRequired was true) the runtime skipped model loading, so the
+   * initial options list may be empty; all model-switch entry points share
+   * this refresh.
    */
-  private async showModelPicker(): Promise<boolean> {
-    // After a fresh login (loginRequired was true), modelOptions may be empty
-    // because the runtime skipped model loading during the loginRequired state.
-    // Refresh from the bridge so the cascade picker always has data.
+  private async refreshModelOptions(): Promise<void> {
     if (this.modelOptions.length === 0 && this.options.listModelOptions) {
-      const refreshed = await this.options.listModelOptions();
-      if (Array.isArray(refreshed) && refreshed.length > 0) {
-        this.modelOptions = [...refreshed];
+      try {
+        const refreshed = await this.options.listModelOptions();
+        if (Array.isArray(refreshed) && refreshed.length > 0) {
+          this.modelOptions = [...refreshed];
+        }
+      } catch (error) {
+        this.addNotice(
+          `Could not load model options: ${error instanceof Error ? error.message : String(error)}`,
+          "warning"
+        );
       }
     }
+  }
 
-    const cascade = providerModelPicker(this.modelOptions, this.model);
+  /**
+   * Quick session-level model switch via the flat picker. Uses the
+   * setTransientModel bridge so the runtime keeps the switch in-memory —
+   * config.json's model.main stays untouched. For persistent main/lite
+   * configuration use /settings → Model providers.
+   */
+  private async showModelPicker(): Promise<boolean> {
+    await this.refreshModelOptions();
+    const picker = modelPicker(this.modelOptions, this.model);
+    if (picker.items.length === 0) return false;
+    const selected = await this.showChoice({
+      title: "Select model",
+      prompt: `Current model: ${this.model}. · session only — saved defaults are unchanged`,
+      help: "Up/Down choose · Enter switch · Esc cancel",
+      items: picker.items.map((item) => ({ ...item, payload: item.value })),
+      selectedIndex: picker.selectedIndex
+    });
+    const modelId = selected?.payload;
+    if (typeof modelId !== "string") return true;
+
+    await this.switchTransientModel(modelId);
+    return true;
+  }
+
+  /**
+   * Session-only model switch. Requires the setTransientModel bridge; without
+   * it (older runtime) the only available switch path persists to config.json,
+   * which contradicts this feature's contract — refuse instead of silently
+   * rewriting saved defaults.
+   */
+  private async switchTransientModel(modelId: string): Promise<void> {
+    if (!this.options.setTransientModel) {
+      this.addNotice(
+        "Session model switching is unavailable in this runtime · use /settings → Model providers.",
+        "muted"
+      );
+      return;
+    }
+    if (this.settingSwitchInFlight) return;
+    this.settingSwitchInFlight = true;
+    try {
+      const previousModel = this.model;
+      const result = await this.options.setTransientModel(modelId);
+      await this.handleResult(result, false, "model");
+      const status = this.model === previousModel ? "already active" : "now";
+      this.addNotice(
+        `Session model ${status}: ${this.model} · saved defaults unchanged.`,
+        "muted"
+      );
+    } catch (error) {
+      this.addNotice(
+        `Could not switch model: ${error instanceof Error ? error.message : String(error)}`,
+        "error"
+      );
+    } finally {
+      this.settingSwitchInFlight = false;
+    }
+  }
+
+  /**
+   * Three-level cascade (provider → main → lite) embedded in the /settings
+   * menu. Persists both selections to config.json and applies the main model
+   * to the current session. Esc at each sub-level returns to the previous
+   * level: lite → main → provider → settings menu.
+   *
+   * Defaults are based on the SAVED config (model.main), not the session
+   * model — a quick /model switch in the session must not silently change
+   * what this persistent-configurator preselects.
+   */
+  private async showModelProviderSettings(): Promise<void> {
+    await this.refreshModelOptions();
+    // Read the saved model config directly — readConfiguredModelAccess() is
+    // gated on a configured API key, but this editor must show config.model
+    // even when credentials are missing or incomplete.
+    const savedModelConfig = await readUserConfig()
+      .then((config) => (isRecord(config.model) ? config.model as Record<string, unknown> : undefined))
+      .catch(() => undefined);
+    const savedModel = typeof savedModelConfig?.main === "string" && savedModelConfig.main.trim()
+      ? savedModelConfig.main
+      : undefined;
+    const savedLite = typeof savedModelConfig?.lite === "string" && savedModelConfig.lite.trim()
+      ? savedModelConfig.lite
+      : undefined;
+
+    const cascade = providerModelPicker(this.modelOptions, savedModel ?? this.model);
     if (!cascade || cascade.providers.items.length === 0) {
-      // No parseable models — let the runtime handle /model as a text command.
-      return false;
+      this.addNotice("No model providers available to configure.", "muted");
+      return;
     }
 
+    let providerIndex = cascade.providers.selectedIndex;
     while (!this.stopped) {
       // Level 1 — provider
       const providerChoice = await this.showChoice({
-        title: "Select provider",
-        prompt: `Current model: ${this.model}.`,
-        help: "Up/Down choose · Enter select · Esc close",
+        title: "Model providers",
+        prompt: "Configure the main and lite models for each provider.",
+        help: "Up/Down choose · Enter select · Esc back to settings",
         items: cascade.providers.items,
-        selectedIndex: cascade.providers.selectedIndex
+        selectedIndex: providerIndex
       });
-      if (!providerChoice) return true; // Esc at top level — exit /model
+      if (!providerChoice) return; // Esc → back to settings menu
+      providerIndex = cascade.providers.items.findIndex((item) => item.value === providerChoice.value);
 
       const group = cascade.groups.find((g) => g.providerId === providerChoice.value);
       if (!group) continue;
@@ -2928,19 +3029,25 @@ class ZCodeTui {
       // Levels 2+3 — main → lite, nested so Esc at lite returns to main
       // (not to the provider picker).
       let confirmed = false;
+      // Track the in-progress main selection so Esc at lite returns to the
+      // model the user just chose, not the saved default.
+      let mainIndex = group.models.items.findIndex((item) => item.value === savedModel);
+      if (mainIndex < 0) mainIndex = group.models.selectedIndex;
       while (!this.stopped && !confirmed) {
         // Level 2 — main model
         const mainChoice = await this.showChoice({
           title: `Select main model · ${group.label}`,
           prompt: "The main model handles agent turns.",
           help: "Up/Down choose · Enter confirm · Esc back to provider",
-          items: group.models.items
+          items: group.models.items,
+          selectedIndex: mainIndex
         });
         if (!mainChoice) break; // Esc → back to provider selection (outer while)
+        mainIndex = group.models.items.findIndex((item) => item.value === mainChoice.value);
 
-        // Level 3 — lite model (optional; default "same as main")
-        // Exclude the selected main model from the candidate list, then append
-        // a "Same as main" entry as the default (last index → selected).
+        // Level 3 — lite model. Preselect the saved lite when it is a
+        // distinct model in this provider; otherwise default to "Same as
+        // main" (last index).
         const liteCandidates = group.models.items
           .filter((item) => item.value !== mainChoice.value)
           .map((item) => ({ ...item, description: undefined }));
@@ -2950,12 +3057,15 @@ class ZCodeTui {
           description: `default · ${mainChoice.label}`
         };
         const liteItems = [...liteCandidates, sameAsMainItem];
+        const savedLiteIndex = liteItems.findIndex(
+          (item) => item.value === savedLite && item.value !== mainChoice.value
+        );
         const liteChoice = await this.showChoice({
           title: `Select lite model · ${group.label}`,
           prompt: "The lite model handles quick tasks and tool summaries.",
           help: "Up/Down choose · Enter confirm · Esc back to main",
           items: liteItems,
-          selectedIndex: liteItems.length - 1
+          selectedIndex: savedLiteIndex >= 0 ? savedLiteIndex : liteItems.length - 1
         });
         if (!liteChoice) continue; // Esc → back to main selection (this while)
 
@@ -2984,10 +3094,10 @@ class ZCodeTui {
         await this.applySettingCommand(`/model ${mainChoice.value}`, "model");
         confirmed = true;
       }
-      if (confirmed) return true;
-      // Esc from main picker → outer while re-opens provider picker
+      // Return to the settings menu after a successful cascade instead of
+      // looping back to the provider picker.
+      if (confirmed) return;
     }
-    return true;
   }
 
   private async showConfiguration(): Promise<void> {
@@ -3019,11 +3129,24 @@ class ZCodeTui {
       const backend = notificationDeliveryLabel(effective.method, diagnostics.backend);
       const methodOverride = Boolean(process.env.ZCODE_TUI_NOTIFICATION_METHOD?.trim());
       const conditionOverride = Boolean(process.env.ZCODE_TUI_NOTIFICATION_CONDITION?.trim());
+      const savedConfig = await readUserConfig()
+        .then((config) => (isRecord(config.model) ? config.model as Record<string, unknown> : undefined))
+        .catch(() => undefined);
+      const savedModelLabel = typeof savedConfig?.main === "string" && savedConfig.main.trim()
+        ? savedConfig.main
+        : undefined;
       const setting = await this.showChoice({
         title: "ZCode settings",
         prompt: feedback,
         help: "Up/Down choose · Enter open · Esc close settings",
         items: [
+          {
+            value: "model-providers",
+            label: "Model providers",
+            description: this.model === savedModelLabel || !savedModelLabel
+              ? `Saved: ${savedModelLabel ?? this.model}`
+              : `Session: ${this.model} · Saved: ${savedModelLabel}`
+          },
           {
             value: "notification-method",
             label: "Notification delivery",
@@ -3043,7 +3166,14 @@ class ZCodeTui {
       });
       if (!setting) return;
 
-      selectedSettingIndex = setting.value === "notification-condition" ? 1 : 0;
+      if (setting.value === "model-providers") {
+        selectedSettingIndex = 0;
+        await this.showModelProviderSettings();
+        feedback = "Changes save immediately · Esc closes settings";
+        continue;
+      }
+
+      selectedSettingIndex = setting.value === "notification-condition" ? 2 : setting.value === "notification-method" ? 1 : 0;
       let next = stored;
       let changedLabel: string;
       let overridden = false;
@@ -3475,12 +3605,13 @@ class ZCodeTui {
 
   private async switchModel(): Promise<void> {
     if (!this.shortcutAvailable()) return;
-    const command = nextPickerCommand(modelPicker(this.modelOptions, this.model), this.model);
-    if (!command) {
+    await this.refreshModelOptions();
+    const next = nextPickerValue(modelPicker(this.modelOptions, this.model), this.model);
+    if (!next) {
       this.addNotice("No alternate model is available.", "muted");
       return;
     }
-    await this.applySettingCommand(command, "model");
+    await this.switchTransientModel(next);
   }
 
   private async switchEffort(): Promise<void> {

--- a/packages/zcode-tui/src/selectors.ts
+++ b/packages/zcode-tui/src/selectors.ts
@@ -35,6 +35,22 @@ export function isModelPickerRequest(input: string): boolean {
   return pickerRequest(input, new Set(["model"]));
 }
 
+/**
+ * Extract the explicit model reference from `/model <provider/model>`.
+ * Returns undefined for the bare picker forms (`/model`, `/model list`) and
+ * malformed references. Runtime aliases are returned as explicit requests so
+ * they also use the session-only transient model bridge.
+ */
+export function explicitModelRequest(input: string): string | undefined {
+  const match = /^\/model\s+(\S+)$/iu.exec(input.trim());
+  const argument = match?.[1];
+  if (!argument || argument.toLowerCase() === "list") return undefined;
+  if (/^(?:main|lite|sonnet|opus|haiku)$/iu.test(argument)) return argument;
+  const separator = argument.indexOf("/");
+  if (separator <= 0 || separator === argument.length - 1) return undefined;
+  return argument;
+}
+
 export function isEffortPickerRequest(input: string): boolean {
   return pickerRequest(input, new Set(["effort", "variant"]));
 }

--- a/packages/zcode-tui/src/shortcuts.ts
+++ b/packages/zcode-tui/src/shortcuts.ts
@@ -35,6 +35,14 @@ export function nextPickerCommand(picker: PickerSpec, currentValue?: string): st
   return picker.items[nextIndex]?.command;
 }
 
+/** Like nextPickerCommand but returns the item value (model id) directly. */
+export function nextPickerValue(picker: PickerSpec, currentValue?: string): string | undefined {
+  if (picker.items.length < 2) return undefined;
+  const currentIndex = picker.items.findIndex((item) => item.value === currentValue);
+  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % picker.items.length;
+  return picker.items[nextIndex]?.value;
+}
+
 export function transcriptPageDirection(data: string): -1 | 1 | undefined {
   if (isKeyRelease(data)) return undefined;
   if (matchesKey(data, "pageUp") || matchesKey(data, "left")) return -1;

--- a/packages/zcode-tui/src/types.ts
+++ b/packages/zcode-tui/src/types.ts
@@ -91,6 +91,7 @@ export interface TuiOptions {
   listWorkspacePathSuggestions?: ListWorkspacePathSuggestions;
   listSkills?: ListSkills;
   listModelOptions?: () => Promise<unknown[]>;
+  setTransientModel?: (modelId: string) => Promise<unknown>;
   recallPreviousInput?: (skip: number) => Promise<unknown>;
   readGoal?: () => Promise<unknown>;
   readTodos?: () => Promise<unknown>;

--- a/scripts/check-runtime.ts
+++ b/scripts/check-runtime.ts
@@ -84,6 +84,7 @@ if (patchRuntimeLoginModelDefaults(runtimeSource) !== runtimeSource
   || !/applyFileRewind:[A-Za-z_$][\w$]*\.applyFileRewind/u.test(runtimeSource)
   || !/listSkills:[A-Za-z_$][\w$]*\.listSkills/u.test(runtimeSource)
   || !/listModelOptions:[A-Za-z_$][\w$]*\.listModelOptions/u.test(runtimeSource)
+  || !/setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel/u.test(runtimeSource)
   || !/subscribeSessionEvents:[A-Za-z_$][\w$]*\.subscribeSessionEvents/u.test(runtimeSource)
   || !/sendBackgroundTaskMessage:[A-Za-z_$][\w$]*\.sendBackgroundTaskMessage/u.test(runtimeSource)) {
   throw new Error("The runtime compatibility patches are missing; run `bun run sync` again.");

--- a/scripts/smoke-tui-features.ts
+++ b/scripts/smoke-tui-features.ts
@@ -85,7 +85,7 @@ try {
   await sendAndWait("\r", "conversation and workspace rewind", /Conversation and workspace rewound[\s\S]*selected input was restored to the editor/i);
   await sendAndSettle("\x15");
   await sendAndWait("/settings\r", "settings picker", /ZCode settings/i);
-  await sendAndWait("\x1b[B\r", "notification timing picker", /When to notify/i);
+  await sendAndWait("\x1b[B\x1b[B\r", "notification timing picker", /When to notify/i);
   await sendAndWait("\x1b[B\r", "saved setting returned to root", /When to notify: always saved · environment override remains active/i);
   const savedConfig = (await Bun.file(join(temporaryHome, ".zcode", "cli", "config.json")).json()) as {
     ui?: { notifications?: { condition?: string } };
@@ -124,18 +124,30 @@ try {
   await sendAndWait("\x1b[Z", "plan mode shortcut", /◈ alpha\/model ─ ◉ plan ─ ⚡ low/i);
   await sendAndWait("\x0e", "model shortcut", /◈ beta\/model ─ ◉ plan ─ ⚡ low/i);
   await sendAndWait("\t", "effort shortcut", /◈ beta\/model ─ ◉ plan ─ ⚡ high/i);
-  await sendAndWait("/model\r", "model provider picker", /Select provider/i);
-  await sendAndWait("alpha\r", "main model picker", /Select main model/i);
+  // /model — flat quick-switch picker (session-level, not persistent)
+  await sendAndWait("/model\r", "model picker", /Select model/i);
+  await sendAndWait("alpha\r", "model picker selection", /◈ alpha\/model ─ ◉ plan ─ ⚡ high/i);
+  // /settings → Model providers — three-level cascade (provider → main → lite)
+  // Use sendAndSettle + a settle delay to flush any buffered key sequences
+  // from prior test steps before driving the Model providers cascade.
+  await sendAndSettle("/settings\r");
+  await waitFor("settings menu (re-opened)", /Model providers\s+(?:Session:|Saved:)/i);
+  await Bun.sleep(renderSettleMilliseconds * 2);
+  await sendAndWait("\r", "model providers entry", /Configure the main and lite/i);
+  await sendAndWait("\r", "provider selected (alpha)", /Select main model/i);
   // Esc at lite → back to main picker (not provider)
   await sendAndWait("\r", "lite model picker with Same as main default", /Select lite model[\s\S]*Same as main/i);
   await sendAndWait("\x1b", "lite Esc back to main", /Select main model/i);
   // Esc at main → back to provider picker
-  await sendAndWait("\x1b", "main Esc back to provider", /Select provider/i);
+  await sendAndWait("\x1b", "main Esc back to provider", /Configure the main and lite/i);
   // Re-enter and complete the full cascade
-  await sendAndWait("alpha\r", "main model picker (re-enter)", /Select main model/i);
+  await sendAndWait("\r", "provider selected (re-enter)", /Select main model/i);
   await sendAndWait("\r", "lite model picker (re-enter)", /Select lite model/i);
   // Press Enter directly — should confirm "Same as main" (the default)
-  await sendAndWait("\r", "model cascade confirm (Same as main default)", /◈ alpha\/model ─ ◉ plan ─ ⚡ high/i);
+  await sendAndWait("\r", "model cascade confirm (Same as main default)", /Model config saved/i);
+  // The cascade returns to the settings menu — Esc to close it and return
+  // to the editor before continuing with /effort.
+  await sendAndSettle("\x1b");
   await sendAndWait("/effort\r", "effort picker", /Select reasoning effort/i);
   await sendAndWait("\x1b[B\r", "effort picker selection", /◈ alpha\/model ─ ◉ plan ─ ⚡ low/i);
   await sendAndWait("\x1b[Z", "build mode shortcut", /◈ alpha\/model ─ ◉ build ─ ⚡ low/i);
@@ -428,7 +440,8 @@ for (const [label, pattern] of [
   ["resumed agent conversation", /You: Fix the recovery issue and rerun the focused test\.[\s\S]*Agent "agent_feature" resumed in the background\./i],
   ["restarted active agent", /Agent "agent_feature" restarted in the background\./i],
   ["paused goal footer", /Goal: Paused \(\/goal resume\)/i],
-  ["model provider picker", /Select provider/i],
+  ["model picker", /Select model/i],
+  ["model providers entry", /Model providers/i],
   ["effort picker", /Select reasoning effort/i],
   ["image attachment", /1 image attached/i],
   ["multiple attachment tokens", /Images[\s\S]*\[Image #1\][\s\S]*\[Image #2\]/i],

--- a/scripts/sync-runtime.ts
+++ b/scripts/sync-runtime.ts
@@ -327,6 +327,8 @@ export function patchRuntimeTuiBridge(runtime: string): string {
   const interruptTurnMarker = ".interruptTurn=async e=>";
   const interruptWaitForIdleMarker = "e?.waitForIdle===!0";
   const queuedInputPromotionMarker = "r?.pendingInputReservationId??r?.queryId??";
+  const transientModelBridgePattern = /\.setTransientModel=async/u;
+  const transientModelOptionPattern = /setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel/u;
   const alreadyPatched = runtime.includes(".loadSessionTranscript=async()=>await(await")
     && runtime.includes(".readGoal=async()=>await(await")
     && runtime.includes(".readTodos=async()=>await(await")
@@ -358,6 +360,8 @@ export function patchRuntimeTuiBridge(runtime: string): string {
     && listSkillsBridgePattern.test(runtime)
     && listSkillsOptionPattern.test(runtime)
     && listModelOptionsOptionPattern.test(runtime)
+    && transientModelBridgePattern.test(runtime)
+    && transientModelOptionPattern.test(runtime)
     && sessionEventsBridgePattern.test(runtime)
     && sessionEventsOptionPattern.test(runtime)
     && taskMessageBridgePattern.test(runtime)
@@ -497,6 +501,12 @@ export function patchRuntimeTuiBridge(runtime: string): string {
   if (!patched.includes(".applyFileRewind=async e=>")) {
     assignments.push(`${bridge}.applyFileRewind=async e=>{let t=await ${getApp}();return await t.runtime?.applyWorkspaceFileRewind?.({targetMessageIds:e})??null}`);
   }
+  // Session-level (transient) model switch: the runtime's setModel persists
+  // model.main to config.json by default; {transient:true} keeps it in-memory
+  // so the /model quick picker does not rewrite saved defaults.
+  if (!patched.includes(".setTransientModel=async")) {
+    assignments.push(`${bridge}.setTransientModel=async e=>await(await ${getApp}()).setModel?.(e,{transient:!0})`);
+  }
   if (!sessionEventsBridgePattern.test(patched)) {
     assignments.push(`${bridge}.subscribeSessionEvents=e=>{let t=!1,r;${getApp}().then(o=>{t||(r=o.runtime?.subscribeEvents?.({onSessionEvent:e}))});return()=>{t=!0,r?.()}}`);
   }
@@ -583,6 +593,9 @@ export function patchRuntimeTuiBridge(runtime: string): string {
   }
   if (!/listModelOptions:[A-Za-z_$][\w$]*\.listModelOptions/u.test(patched)) {
     optionFields.push(`listModelOptions:${submitBridge}.listModelOptions`);
+  }
+  if (!/setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel/u.test(patched)) {
+    optionFields.push(`setTransientModel:${submitBridge}.setTransientModel`);
   }
   if (!sessionEventsOptionPattern.test(patched)) {
     optionFields.push(`subscribeSessionEvents:${submitBridge}.subscribeSessionEvents`);

--- a/test/fixtures/tui-features.ts
+++ b/test/fixtures/tui-features.ts
@@ -201,6 +201,10 @@ await runTui({
     { alias: "main", id: "alpha/model", name: "Alpha" },
     { alias: "lite", id: "beta/model", name: "Beta" }
   ],
+  setTransientModel: async (modelId: string) => {
+    model = modelId;
+    return { model: modelId };
+  },
   effortOptions: [
     { id: "low", label: "Low" },
     { id: "high", label: "High" }

--- a/test/selectors.test.ts
+++ b/test/selectors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   effortPicker,
+  explicitModelRequest,
   isEffortPickerRequest,
   isModelPickerRequest,
   modelPicker,
@@ -62,6 +63,22 @@ describe("TUI selectors", () => {
     expect(isEffortPickerRequest("/effort")).toBe(true);
     expect(isEffortPickerRequest("/variant list")).toBe(true);
     expect(isEffortPickerRequest("/effort high")).toBe(false);
+  });
+
+  test("extracts explicit model refs, aliases, and nested model IDs", () => {
+    expect(explicitModelRequest("/model zai/glm-5.2")).toBe("zai/glm-5.2");
+    expect(explicitModelRequest("/model custom/model")).toBe("custom/model");
+    expect(explicitModelRequest("/model provider/org/model")).toBe("provider/org/model");
+    // Bare picker and list forms are handled by showModelPicker.
+    expect(explicitModelRequest("/model")).toBeUndefined();
+    expect(explicitModelRequest("/model list")).toBeUndefined();
+    // Runtime-resolved aliases also use the transient session switch path.
+    expect(explicitModelRequest("/model main")).toBe("main");
+    expect(explicitModelRequest("/model lite")).toBe("lite");
+    expect(explicitModelRequest("/model opus")).toBe("opus");
+    // Malformed refs fall through to the runtime's own error handling.
+    expect(explicitModelRequest("/model not-a-ref")).toBeUndefined();
+    expect(explicitModelRequest("/effort high")).toBeUndefined();
   });
 
   test("groups runtime modelOptions into a provider cascade", () => {

--- a/test/sync-runtime.test.ts
+++ b/test/sync-runtime.test.ts
@@ -690,6 +690,40 @@ describe("runtime synchronization", () => {
     expect(modernPatched).not.toContain("Array.isArray(t.targetMessageIds)");
   });
 
+  test("upgrades an already-patched runtime that lacks the transient model bridge", () => {
+    // Simulate a runtime patched by an older patchRuntimeTuiBridge: the
+    // fixture above fully patched (minus setTransientModel, which did not
+    // exist yet). The patch must detect the gap and add the bridge + option
+    // instead of short-circuiting as "already patched".
+    const runtime = [
+      "function R(e,t){return f(e,{rewindCreatedMessageId:t.revert?.createdMessageID,rewindKeptMessageIds:t.revert?.keptMessageIDs,rewindTargetMessageId:t.revert?.targetMessageID})}",
+      "async function L(e){if(!e.sessionStore)return[];let t=await e.sessionStore.messages({sessionID:e.sessionId});return p(t)}",
+      'function p(e){let t=[];for(let r of e){if(r.info.role==="user"){let l=r.text;t.push({content:l,role:"user"});continue}let n=[],s=[],u=r.text;t.push({content:u,...s.length>0?{parts:s}:{},role:"agent"})}return t}',
+      "function c(e,t){if(t.targetMessageId)return O(e,[t.targetMessageId]);let r=P(e,t.targetCheckpointId);return r?[r]:[]}",
+      "E.sendInput=async(A,$)=>{let c=t.runtime.getActiveTurnInfo();if(c)return t.runtime.steerTurn({commandKind:$?.commandKind,inputId:$?.inputId,queryId:$?.queryId,expectedTurnId:$?.expectedTurnId,input:A});return Kvt(await S(),D,O1(t))},",
+      'listSkills:k(()=>H(e),"listSkills"),',
+      "E.recallPreviousInput=async A=>await(await S()).recallPreviousInputHistory?.(A)??null,",
+      "CVr(E,S,r);",
+      "return c({recallPreviousInput:g.recallPreviousInput,sendInput:g.sendInput,submitPrompt:g})"
+    ].join("").replace(
+      "E.sendInput",
+      'loadSessionTranscript:a(async()=>await dUr({sessionId:e.sessionId,sessionStore:e.sessionStore}),"loadSessionTranscript"),readTodos:E.sendInput'
+    );
+    // Fully apply the current patch, then strip only the transient-model
+    // injections to model an older patch generation.
+    const fullyPatched = patchRuntimeTuiBridge(runtime);
+    const stripped = fullyPatched
+      .replace(/[A-Za-z_$]+\.setTransientModel=async e=>await\(await [A-Za-z_$]+\(\)\)\.setModel\?\.\(e,\{transient:!0\}\),/u, "")
+      .replace(/setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel,/u, "");
+    expect(stripped).not.toMatch(/\.setTransientModel=async/u);
+    expect(stripped).not.toMatch(/setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel/u);
+
+    const patched = patchRuntimeTuiBridge(stripped);
+    expect(patched).toMatch(/\.setTransientModel=async/u);
+    expect(patched).toMatch(/setTransientModel:[A-Za-z_$][\w$]*\.setTransientModel/u);
+    expect(patchRuntimeTuiBridge(patched)).toBe(patched);
+  });
+
   test("auto-backgrounds long Agent calls while preserving explicit configuration", () => {
     const runtime = "function delay(){return{autoBackgroundMs:this.config.subagents?.autoBackgroundMs,outputRootDir:'tasks'}}";
     const patched = patchRuntimeAgentAutoBackground(runtime);


### PR DESCRIPTION
  - move persistent main/lite model configuration to settings
  - route model picker, aliases, explicit refs, and shortcuts through transient switching
  - refresh model options after login and surface switch feedback
  - add runtime bridge compatibility checks and test coverage