### PR TITLE
fix(cli): align help with the bundled runtime parser

### DIFF
--- a/scripts/sync-runtime.ts
+++ b/scripts/sync-runtime.ts
@@ -648,6 +648,38 @@ export function patchRuntimeOAuthHttpErrors(runtime: string): string {
   );
 }
 
+const legacyHeadlessOptions = [
+  "settings",
+  "permission-mode",
+  "max-turns",
+  "allowed-tools",
+  "allow-main-worktree-yolo"
+] as const;
+
+/** Hide compatibility options that the extracted runtime advertises but cannot parse. */
+export function patchRuntimeCliHelpContract(runtime: string): string {
+  const parserEnd = runtime.indexOf('strict:!0}),"parseGlobalArgs"');
+  const parserStart = parserEnd < 0 ? -1 : runtime.lastIndexOf("options:{", parserEnd);
+  if (parserStart < 0 || parserEnd < 0) {
+    throw new Error(
+      "ZCode runtime is incompatible with the CLI help contract patch (global parser anchor missing)."
+    );
+  }
+
+  const parser = runtime.slice(parserStart, parserEnd);
+  let patched = runtime;
+  for (const option of legacyHeadlessOptions) {
+    const escaped = option.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+    const parserOption = new RegExp(
+      `(?:^|[,{])"?${escaped}"?:\\{[^}]*type:"(?:string|boolean)"`,
+      "u"
+    );
+    if (parserOption.test(parser)) continue;
+    patched = patched.replace(new RegExp(`^  --${escaped}\\s[^\\n]*\\n`, "gmu"), "");
+  }
+  return patched;
+}
+
 /** Avoid Undici rejecting bodies on the Fetch statuses that must be bodyless. */
 export function hasRuntimeHttpNoContentGuard(runtime: string): boolean {
   return /([A-Za-z_$][\w$]*)\.statusCode===204\|\|\1\.statusCode===205\|\|\1\.statusCode===304\?void 0:/u
@@ -887,15 +919,17 @@ async function installTuiBridge(nextVendor: string): Promise<void> {
   const runtime = await readFile(runtimePath, "utf8");
   await writeFile(
     runtimePath,
-    patchRuntimeContextCacheFromParts(
-      patchRuntimeLoginModelDefaults(
-        patchRuntimeZaiDesktopOAuth(
-          patchRuntimeOAuthHttpErrors(
-            patchRuntimeHttpNoContent(
-              patchRuntimeAgentAutoBackground(
-                patchRuntimeDetachedAgentLifecycle(
-                  patchRuntimeTerminalToolProjection(
-                    patchRuntimeGoalFailurePause(patchRuntimeTuiBridge(runtime))
+    patchRuntimeCliHelpContract(
+      patchRuntimeContextCacheFromParts(
+        patchRuntimeLoginModelDefaults(
+          patchRuntimeZaiDesktopOAuth(
+            patchRuntimeOAuthHttpErrors(
+              patchRuntimeHttpNoContent(
+                patchRuntimeAgentAutoBackground(
+                  patchRuntimeDetachedAgentLifecycle(
+                    patchRuntimeTerminalToolProjection(
+                      patchRuntimeGoalFailurePause(patchRuntimeTuiBridge(runtime))
+                    )
                   )
                 )
               )

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -59,7 +59,8 @@ const runtimeValueOptions = new Set([
   "--mode",
   "--permission-mode",
   "--resume",
-  "--settings"
+  "--settings",
+  "--surface"
 ]);
 const runtimeVariadicOptions = new Set(["--disallowedTools", "--disallowed-tools"]);
 

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -152,6 +152,15 @@ describe("launcher routing", () => {
       "--prompt",
       "inspect this page"
     ]);
+    expect(
+      withDefaultBrowserUse(["--surface", "terminal", "--prompt", "inspect this page"])
+    ).toEqual([
+      "--browser-use=headless",
+      "--surface",
+      "terminal",
+      "--prompt",
+      "inspect this page"
+    ]);
     expect(withDefaultBrowserUse(["--target=verify the site"])).toEqual([
       "--browser-use=headless",
       "--target=verify the site"
@@ -215,6 +224,7 @@ describe("launcher routing", () => {
   test("recognizes TUI invocations after consuming global option values", () => {
     expect(isTuiRuntimeInvocation([])).toBe(true);
     expect(isTuiRuntimeInvocation(["--cwd", "/tmp/project", "--settings", "custom.json", "tui"])).toBe(true);
+    expect(isTuiRuntimeInvocation(["--surface", "terminal", "tui"])).toBe(true);
     expect(isTuiRuntimeInvocation(["--browser-use", "headless", "--cwd", "/tmp/project", "tui"])).toBe(true);
     expect(isTuiRuntimeInvocation(["--prompt", "inspect this page"])).toBe(false);
     expect(isTuiRuntimeInvocation(["plugins", "list"])).toBe(false);

--- a/test/sync-runtime.test.ts
+++ b/test/sync-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   parseArgs,
   parseRuntimeLock,
   patchRuntimeAgentAutoBackground,
+  patchRuntimeCliHelpContract,
   patchRuntimeContextCacheFromParts,
   patchRuntimeDetachedAgentLifecycle,
   patchRuntimeGoalFailurePause,
@@ -75,6 +76,29 @@ describe("runtime synchronization", () => {
     });
     expect(() => parseArgs(["--app", "/tmp/ZCode.app", "--lock", "runtime.json"])).toThrow(/cannot/);
     expect(() => parseArgs(["--version", "3.3.5"])).toThrow(/--app/);
+  });
+
+  test("hides advertised CLI options until the runtime parser supports them", () => {
+    const runtime = [
+      'help:s(e=>`Options:',
+      '  --settings <path>  Load settings',
+      '  --permission-mode <mode>  Legacy alias',
+      '  --max-turns <n>  Maximum turns',
+      '  --allowed-tools <list>  Tool allowlist',
+      '  --allow-main-worktree-yolo  Legacy compatibility',
+      '  --mode <mode>  Permission mode',
+      '`)',
+      'parse=s(e=>parseArgs({options:{"max-turns":{type:"string"},mode:{type:"string"}},strict:!0}),"parseGlobalArgs")'
+    ].join("\n");
+
+    const patched = patchRuntimeCliHelpContract(runtime);
+    expect(patched).not.toContain("--settings");
+    expect(patched).not.toContain("--permission-mode");
+    expect(patched).toContain("--max-turns <n>");
+    expect(patched).not.toContain("--allowed-tools");
+    expect(patched).not.toContain("--allow-main-worktree-yolo");
+    expect(patched).toContain("--mode <mode>");
+    expect(patchRuntimeCliHelpContract(patched)).toBe(patched);
   });
 
   test("validates locked runtime inputs before downloading", () => {


### PR DESCRIPTION
## Summary

Keep the launcher and `zcode --help` aligned with the strict global option parser in the extracted runtime.

The 3.8.1 / runtime 0.16.3 help currently advertises five options that immediately fail with `Unknown option`:

- `--settings`
- `--permission-mode`
- `--max-turns`
- `--allowed-tools`
- `--allow-main-worktree-yolo`

This patch removes only unsupported help lines during runtime synchronization. It inspects the actual global parser first, so an option automatically remains visible once a future upstream runtime registers it. It does not silently accept or ignore a restriction that the runtime cannot enforce.

It also adds the supported `--surface <value>` option to the launcher classifier. Without this, `--surface terminal --prompt ...` lost the default Browser Use injection, and `--surface terminal tui` was misclassified as non-TUI.

## Why

Automation and agent integrations commonly derive capabilities from `--help`. Advertising nonfunctional limits or permission flags is especially risky because callers may assume a sandbox, tool allowlist, or turn limit is active when it is not.

The remaining documented global options were checked against the bundled strict parser. A normal Coding Plan headless request using `--prompt --mode plan --json` also completed successfully.

## Validation

Using ZCode Desktop 3.8.1 and runtime 0.16.3:

- `bun test test/launcher.test.ts test/launcher-runtime.test.ts test/sync-runtime.test.ts`: 44 passed
- `bun run typecheck`: passed
- `bun run check`: passed
- patched real runtime `--help`: no unsupported options listed
- supported option smoke (`--mode plan --help`): passed
- unsupported option remains explicitly rejected rather than being silently ignored
- `--surface` prompt and TUI launcher classification covered by regressions

## Scope

This intentionally fixes the public CLI contract only. Implementing `--settings`, a headless tool allowlist, or a global turn limit requires real runtime semantics and should not be approximated in the launcher.
