### PR TITLE
fix(runtime): recover wrapped transport failures safely

### DIFF
--- a/scripts/check-runtime.ts
+++ b/scripts/check-runtime.ts
@@ -12,9 +12,11 @@ import {
   extractRuntimeCapabilities,
   hasRuntimeCliHelpContract,
   hasRuntimeHttpNoContentGuard,
+  hasRuntimeNetworkRetryGuard,
   patchRuntimeGoalFailurePause,
   patchRuntimeHttpNoContent,
   patchRuntimeLoginModelDefaults,
+  patchRuntimeNetworkRetryClassification,
   parseRuntimePatchReports,
   runtimePatchPlan,
   supportsMultiMessageFileRewind
@@ -69,6 +71,8 @@ if (patchRuntimeLoginModelDefaults(runtimeSource) !== runtimeSource
   || (patchEnabled("goal-failure-pause") && patchRuntimeGoalFailurePause(runtimeSource) !== runtimeSource)
   || patchRuntimeHttpNoContent(runtimeSource) !== runtimeSource
   || !hasRuntimeHttpNoContentGuard(runtimeSource)
+  || patchRuntimeNetworkRetryClassification(runtimeSource) !== runtimeSource
+  || !hasRuntimeNetworkRetryGuard(runtimeSource)
   || (patchEnabled("cli-help-contract") && !hasRuntimeCliHelpContract(runtimeSource))
   || !runtimeSource.includes(".readRuntimeProjection=async()=>{let $zRuntimeProjectionBridge=await ")
   || !runtimeSource.includes('"plugin://"')

--- a/scripts/sync-runtime.ts
+++ b/scripts/sync-runtime.ts
@@ -904,6 +904,155 @@ export function patchRuntimeHttpNoContent(runtime: string): string {
   return changed ? patched : runtime;
 }
 
+function escapeRegExpName(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function countRegExpMatches(source: string, pattern: RegExp): number {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return Array.from(source.matchAll(new RegExp(pattern.source, flags))).length;
+}
+
+/** Detect the local transport classifier while preserving the emitted-output retry boundary. */
+export function hasRuntimeNetworkRetryGuard(runtime: string): boolean {
+  return runtime.includes("var $zTransportCodes=[")
+    && runtime.includes("function $zTransportCode(e){")
+    && runtime.includes("function $zTransportChain(e,t){")
+    && /if\(\$zTransportChain\(e,new WeakSet\)\)return!0;return [A-Za-z_$][\w$]*\(e\)\}/u.test(runtime)
+    && /\|\|\$zTransportChain\([A-Za-z_$][\w$]*,new WeakSet\)\)return\{code:/u.test(runtime)
+    && /\|\|\$zTransportChain\([A-Za-z_$][\w$]*,new WeakSet\)\)return!0;if\(t!==void 0\)return!1;/u.test(runtime)
+    && /function [A-Za-z_$][\w$]*\(e\)\{return e\.emittedRetryBoundaryEvent\|\|e\.attempt>=e\.maxAttempts\|\|e\.failure\.reason===[A-Za-z_$][\w$]*\.Cancelled\?!1:/u.test(runtime);
+}
+
+/**
+ * Recover transport failures whose deep `cause.code` is hidden by a wrapping
+ * `model_request_failed` code. The emitted-output gate remains unchanged: once
+ * content is visible, the turn-level stream recovery owns discard/anchor logic.
+ */
+export function patchRuntimeNetworkRetryClassification(runtime: string): string {
+  if (hasRuntimeNetworkRetryGuard(runtime)) return runtime;
+  if (runtime.includes("function $zTransportCode(e){")
+    || runtime.includes("function $zTransportChain(e,t){")) {
+    throw new Error("ZCode runtime contains a partial network retry patch.");
+  }
+
+  const whitelistPattern = /function ([A-Za-z_$][\w$]*)\(e\)\{let t=e\?\.toUpperCase\(\);return t==="ECONNRESET"\|\|t==="ECONNREFUSED"\|\|t==="EAI_AGAIN"\|\|t==="ENOTFOUND"\|\|t==="ENETUNREACH"\|\|t==="EHOSTUNREACH"\|\|t==="UND_ERR_SOCKET"\|\|t==="UND_ERR_CONNECT_TIMEOUT"\}/u;
+  const extractorPattern = /function ([A-Za-z_$][\w$]*)\(e\)\{return ([A-Za-z_$][\w$]*)\(e,new WeakSet\)\}function \2\(e,t\)\{if\(([A-Za-z_$][\w$]*)\(e,t\)\)return;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(e\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\4,"code"\);if\(\6\)return \6;let [A-Za-z_$][\w$]*=\4\.cause;if\([A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*!==e\)return \2\([A-Za-z_$][\w$]*,t\)\}/u;
+  const classifierPattern = /function ([A-Za-z_$][\w$]*)\(e,t\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(e\),[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\2\),([A-Za-z_$][\w$]*)=EXTRACTOR\(\2\),/u;
+  const streamGatePattern = /function ([A-Za-z_$][\w$]*)\(e\)\{return e\.emittedRetryBoundaryEvent\|\|e\.attempt>=e\.maxAttempts\|\|e\.failure\.reason===([A-Za-z_$][\w$]*)\.Cancelled\?!1:/u;
+
+  const whitelistMatch = whitelistPattern.exec(runtime);
+  const extractorMatch = extractorPattern.exec(runtime);
+  if (!whitelistMatch || !extractorMatch) {
+    throw new Error("ZCode runtime is incompatible with the network retry patch (error-code anchors missing).");
+  }
+
+  const whitelist = whitelistMatch[1]!;
+  const extractor = extractorMatch[1]!;
+  const seen = extractorMatch[3]!;
+  const normalizer = extractorMatch[5]!;
+  const stringGetter = extractorMatch[7]!;
+  const classifierFullPattern = new RegExp(
+    classifierPattern.source.replace("EXTRACTOR", escapeRegExpName(extractor)),
+    "u"
+  );
+  const classifier = classifierFullPattern.exec(runtime);
+  if (!classifier) {
+    throw new Error("ZCode runtime is incompatible with the network retry patch (classifier anchor missing).");
+  }
+  const classifierError = classifier[2]!;
+  const classifierCode = classifier[3]!;
+
+  const networkBranchPattern = new RegExp(
+    `if\\(${escapeRegExpName(whitelist)}\\(${escapeRegExpName(classifierCode)}\\)\\)return\\{code:([A-Za-z_$][\\w$]*)\\.ModelRequestFailed,message:"Network connection failed for the provider request\\."`,
+    "u"
+  );
+  const networkBranch = networkBranchPattern.exec(runtime);
+  const classifierEnd = runtime.indexOf("function ", classifier.index + classifier[0].length);
+  if (!networkBranch || networkBranch.index < classifier.index
+    || (classifierEnd >= 0 && networkBranch.index >= classifierEnd)) {
+    throw new Error("ZCode runtime is incompatible with the network retry patch (network branch anchor missing).");
+  }
+
+  const retryDecisionPattern = new RegExp(
+    `function ([A-Za-z_$][\\w$]*)\\(e,t\\)\\{if\\(t\\)\\{if\\(${escapeRegExpName(whitelist)}\\(t\\)\\|\\|([A-Za-z_$][\\w$]*)\\.has\\(t\\)\\)return!0;let ([A-Za-z_$][\\w$]*)=t\\.toLowerCase\\(\\);if\\(\\3==="network_error"\\|\\|\\3==="network_error_retryable"\\)return!0\\}return ([A-Za-z_$][\\w$]*)\\(e\\)\\}`,
+    "u"
+  );
+  const retryDecision = retryDecisionPattern.exec(runtime);
+  if (!retryDecision) {
+    throw new Error("ZCode runtime is incompatible with the network retry patch (retry decision anchor missing).");
+  }
+
+  const staleStreamPattern = new RegExp(
+    `function ([A-Za-z_$][\\w$]*)\\(e,t\\)\\{let ([A-Za-z_$][\\w$]*)=([A-Za-z_$][\\w$]*)\\(e\\);if\\(([A-Za-z_$][\\w$]*)\\(\\2\\)\\|\\|([A-Za-z_$][\\w$]*)\\(${escapeRegExpName(extractor)}\\(\\2\\)\\)\\)return!0;`,
+    "u"
+  );
+  const staleStream = staleStreamPattern.exec(runtime);
+  if (!staleStream) {
+    throw new Error("ZCode runtime is incompatible with the network retry patch (stale stream anchor missing).");
+  }
+
+  for (const [pattern, label] of [
+    [whitelistPattern, "network error-code whitelist"],
+    [extractorPattern, "cause-chain error-code extractor"],
+    [classifierFullPattern, "model request failure classifier"],
+    [networkBranchPattern, "classifier network branch"],
+    [retryDecisionPattern, "final retry decision"],
+    [staleStreamPattern, "stale stream detector"],
+    [streamGatePattern, "emitted-output stream gate"]
+  ] as const) {
+    if (countRegExpMatches(runtime, pattern) !== 1) {
+      throw new Error(`ZCode runtime is incompatible with the network retry patch (${label} is not unique).`);
+    }
+  }
+
+  const transportCodes = [
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "EAI_AGAIN",
+    "ENOTFOUND",
+    "ENETUNREACH",
+    "EHOSTUNREACH",
+    "EPIPE",
+    "CONNECTIONCLOSED",
+    "ETIMEDOUT",
+    "ETIMEOUT",
+    "UND_ERR_SOCKET",
+    "UND_ERR_CONNECT_TIMEOUT",
+    "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_BODY_TIMEOUT"
+  ];
+  const transportText = JSON.stringify(transportCodes);
+  const chainProbe = [
+    `var $zTransportCodes=${transportText};`,
+    "function $zTransportCode(e){let t=e?.trim().toUpperCase();return!!t&&$zTransportCodes.includes(t)}",
+    "function $zTransportText(e){let t=e?.toUpperCase();return!!t&&$zTransportCodes.some(r=>t.includes(r))}",
+    `function $zTransportChain(e,t){if(${seen}(e,t))return!1;let r=${normalizer}(e),n=${normalizer}(r.error),o=${normalizer}(r.context);if($zTransportCode(${stringGetter}(r,"code"))||$zTransportCode(${stringGetter}(r,"providerCode"))||$zTransportCode(${stringGetter}(n,"code"))||$zTransportCode(${stringGetter}(n,"providerCode"))||$zTransportCode(${stringGetter}(o,"code"))||$zTransportCode(${stringGetter}(o,"providerCode"))||$zTransportText(${stringGetter}(r,"message"))||$zTransportText(${stringGetter}(n,"message"))||$zTransportText(${stringGetter}(o,"message")))return!0;let i=r.cause;return i&&i!==e?$zTransportChain(i,t):!1}`
+  ].join("");
+
+  let patched = runtime.replace(
+    retryDecisionPattern,
+    (_match, decision: string, reasonSet: string, reason: string, fallback: string) => (
+      `${chainProbe}function ${decision}(e,t){if(t){if(${whitelist}(t)||${reasonSet}.has(t))return!0;let ${reason}=t.toLowerCase();if(${reason}==="network_error"||${reason}==="network_error_retryable")return!0}if($zTransportChain(e,new WeakSet))return!0;return ${fallback}(e)}`
+    )
+  );
+  patched = patched.replace(
+    networkBranchPattern,
+    (_match, codeEnum: string) => `if(${whitelist}(${classifierCode})||$zTransportChain(${classifierError},new WeakSet))return{code:${codeEnum}.ModelRequestFailed,message:"Network connection failed for the provider request."`
+  );
+  patched = patched.replace(
+    staleStreamPattern,
+    (_match, detector: string, error: string, unwrap: string, idle: string, staleCode: string) => (
+      `function ${detector}(e,t){let ${error}=${unwrap}(e);if(${idle}(${error})||${staleCode}(${extractor}(${error}))||$zTransportChain(${error},new WeakSet))return!0;`
+    )
+  );
+
+  if (!hasRuntimeNetworkRetryGuard(patched)) {
+    throw new Error("ZCode runtime network retry patch failed postcondition verification.");
+  }
+  return patched;
+}
+
 export function patchRuntimeZaiDesktopOAuth(runtime: string): string {
   if (runtime.includes('ZCODE_CLI_OAUTH_CALLBACK_STDIN==="1"')) return runtime;
 
@@ -1104,6 +1253,12 @@ export const runtimePatchPlan: readonly RuntimePatchDefinition[] = [
     requirement: "required",
     apply: patchRuntimeHttpNoContent,
     verify: hasRuntimeHttpNoContentGuard
+  },
+  {
+    id: "network-retry-classification",
+    requirement: "required",
+    apply: patchRuntimeNetworkRetryClassification,
+    verify: hasRuntimeNetworkRetryGuard
   },
   {
     id: "oauth-http-errors",

--- a/test/fixtures/network-reset-server.mjs
+++ b/test/fixtures/network-reset-server.mjs
@@ -1,0 +1,65 @@
+import { createServer } from "node:http";
+
+function streamChunk(id, content, finishReason = null) {
+  return `data: ${JSON.stringify({
+    id,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1_000),
+    model: "glm-5.2",
+    choices: [{
+      index: 0,
+      delta: content ? { role: "assistant", content } : {},
+      finish_reason: finishReason
+    }]
+  })}\n\n`;
+}
+
+let streamingRequests = 0;
+const server = createServer(async (request, response) => {
+  let body = "";
+  for await (const chunk of request) body += chunk.toString();
+  const parsed = body ? JSON.parse(body) : {};
+  if (request.url !== "/v1/chat/completions") {
+    response.writeHead(404).end();
+    return;
+  }
+  if (parsed.stream !== true) {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({
+      id: "chatcmpl-non-stream",
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1_000),
+      model: "glm-5.2",
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: "RECOVERED_FINAL" },
+        finish_reason: "stop"
+      }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }));
+    return;
+  }
+
+  streamingRequests += 1;
+  process.stdout.write(`REQUEST ${streamingRequests}\n`);
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  if (streamingRequests === 1) {
+    response.write(streamChunk("chatcmpl-reset", "PARTIAL_SHOULD_BE_DISCARDED"));
+    setTimeout(() => response.socket?.destroy(), 25);
+    return;
+  }
+
+  response.write(streamChunk("chatcmpl-recovered", "RECOVERED_FINAL"));
+  response.write(streamChunk("chatcmpl-recovered", "", "stop"));
+  response.end("data: [DONE]\n\n");
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Fixture server has no TCP port.");
+  process.stdout.write(`READY ${address.port}\n`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => server.close(() => process.exit(0)));
+}

--- a/test/fixtures/runtime-keepalive.mjs
+++ b/test/fixtures/runtime-keepalive.mjs
@@ -1,0 +1,3 @@
+// Keep the headless Node process alive long enough for Undici to surface the
+// reset; the interactive TUI already has terminal handles that serve this role.
+setTimeout(() => {}, 5_000);

--- a/test/runtime-network-retry.test.ts
+++ b/test/runtime-network-retry.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const fixtureProcesses: ChildProcessWithoutNullStreams[] = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(fixtureProcesses.splice(0).map(async (child) => {
+    if (child.exitCode !== null) return;
+    const closed = once(child, "close");
+    child.kill("SIGTERM");
+    await closed;
+  }));
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => (
+    rm(directory, { recursive: true, force: true })
+  )));
+});
+
+async function startResetServer(node: string): Promise<{
+  child: ChildProcessWithoutNullStreams;
+  output: () => string;
+  port: number;
+  stderr: () => string;
+}> {
+  const child = spawn(node, [join(root, "test", "fixtures", "network-reset-server.mjs")], {
+    cwd: root,
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+  fixtureProcesses.push(child as ChildProcessWithoutNullStreams);
+  let output = "";
+  let errorOutput = "";
+  let pending = "";
+  let ready = false;
+  const port = await new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Reset server did not start. ${errorOutput}`)), 5_000);
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      output += text;
+      pending += text;
+      for (;;) {
+        const newline = pending.indexOf("\n");
+        if (newline < 0) break;
+        const line = pending.slice(0, newline).trim();
+        pending = pending.slice(newline + 1);
+        const match = /^READY (\d+)$/u.exec(line);
+        if (match?.[1] && !ready) {
+          ready = true;
+          clearTimeout(timer);
+          resolve(Number(match[1]));
+        }
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      errorOutput += chunk.toString("utf8");
+    });
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      if (ready) return;
+      clearTimeout(timer);
+      reject(new Error(`Reset server exited with ${code}. ${errorOutput}`));
+    });
+  });
+  return {
+    child: child as ChildProcessWithoutNullStreams,
+    output: () => output,
+    port,
+    stderr: () => errorOutput
+  };
+}
+
+test("recovers a real partial SSE connection reset without concatenating attempts", async () => {
+  const node = Bun.which("node");
+  if (!node) throw new Error("Node.js is required for runtime retry integration tests.");
+
+  const server = await startResetServer(node);
+  const home = await mkdtemp(join(tmpdir(), "zcode-network-retry-"));
+  temporaryDirectories.push(home);
+  const workspace = join(home, "workspace");
+  await mkdir(workspace, { recursive: true });
+
+  const config = await Bun.file(new URL("../config.example.json", import.meta.url)).json() as {
+    features: Record<string, unknown>;
+    logging: Record<string, unknown>;
+    mcp: { servers: Record<string, unknown> };
+    memory: Record<string, unknown>;
+    model: Record<string, unknown>;
+    plugins: Record<string, unknown>;
+    provider: Record<string, unknown>;
+    skills: Record<string, unknown>;
+    storage: Record<string, unknown>;
+  };
+  const defaultZai = config.provider.zai as { models: Record<string, unknown> };
+  config.provider.zai = {
+    kind: "openai-compatible",
+    name: "Retry fixture",
+    options: {
+      apiKey: "fixture-key",
+      apiKeyRequired: true,
+      baseURL: `http://127.0.0.1:${server.port}/v1`
+    },
+    headers: {},
+    models: defaultZai.models
+  };
+  config.model = { main: "zai/glm-5.2", lite: "zai/glm-5.2" };
+  config.storage = {
+    dir: join(home, ".zcode"),
+    sessionDbPath: join(home, ".zcode", "cli", "db", "db.sqlite")
+  };
+  config.features = {
+    compact: false,
+    rewind: false,
+    subagent: false,
+    memory: false,
+    skill: false,
+    mcp: false
+  };
+  config.memory = { use: false, write: false, autoConsolidate: false };
+  config.plugins = {
+    enabled: false,
+    dirs: [],
+    enabledPlugins: {},
+    options: {},
+    suppressedBuiltins: []
+  };
+  config.skills = { enabled: false, includeInstructions: false, metadataBudget: 20_000, roots: [] };
+  config.mcp = { servers: {} };
+  config.logging = { level: "error", format: "text" };
+  const configDirectory = join(home, ".zcode", "cli");
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(join(configDirectory, "config.json"), `${JSON.stringify(config, null, 2)}\n`);
+
+  try {
+    const child = Bun.spawn([
+      node,
+      "--import",
+      join(root, "test", "fixtures", "runtime-keepalive.mjs"),
+      "vendor/zcode.cjs",
+      "--prompt",
+      "Return the fixture response.",
+      "--cwd",
+      workspace,
+      "--no-color",
+      "--output-format",
+      "stream-json",
+      "--surface",
+      "terminal",
+      "--mode",
+      "plan"
+    ], {
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        NO_UPDATE_NOTIFIER: "1",
+        ZCODE_DISABLE_UPDATE_CHECK: "1",
+        ZCODE_MODEL_RETRY_BASE_DELAY_MS: "0",
+        ZCODE_MODEL_RETRY_MAX_RETRIES: "1",
+        ZCODE_NODE: node
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe"
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text()
+    ]);
+    const output = stdout.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as {
+      payload?: Record<string, unknown>;
+      response?: string;
+      type?: string;
+    });
+    const result = output.findLast((entry) => entry.type === "result");
+    const requestStarts = output.filter((entry) => entry.payload?.type === "model_request_started");
+    const requestCount = server.output().split("\n").filter((line) => line.startsWith("REQUEST ")).length;
+
+    expect(code, `${stderr}\nserver:\n${server.output()}${server.stderr()}`).toBe(0);
+    expect(requestCount, stdout).toBe(2);
+    expect(requestStarts).toHaveLength(2);
+    expect(requestStarts[1]?.payload?.streamRecovery).toMatchObject({ retryNumber: 1 });
+    expect(result?.response).toBe("RECOVERED_FINAL");
+    expect(result?.response).not.toContain("PARTIAL_SHOULD_BE_DISCARDED");
+  } finally {
+    if (server.child.exitCode === null) {
+      const closed = once(server.child, "close");
+      server.child.kill("SIGTERM");
+      await closed;
+    }
+  }
+}, 30_000);

--- a/test/sync-runtime.test.ts
+++ b/test/sync-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   formatRuntimeCompatibilityFailure,
   hasRuntimeCliHelpContract,
   hasRuntimeHttpNoContentGuard,
+  hasRuntimeNetworkRetryGuard,
   manifestUrl,
   parseArgs,
   parseRuntimePatchReports,
@@ -21,6 +22,7 @@ import {
   patchRuntimeGoalFailurePause,
   patchRuntimeHttpNoContent,
   patchRuntimeLoginModelDefaults,
+  patchRuntimeNetworkRetryClassification,
   patchRuntimeOAuthHttpErrors,
   patchRuntimeTerminalToolProjection,
   patchRuntimeTuiBridge,
@@ -216,6 +218,117 @@ describe("runtime synchronization", () => {
       "runtime without the HTTP wrapper"
     );
     expect(hasRuntimeHttpNoContentGuard("runtime without the HTTP wrapper")).toBe(false);
+  });
+
+  test("classifies wrapped transport failures without retrying in place after output", () => {
+    const runtime = [
+      "var yt2={ModelRequestFailed:'model_request_failed',ProviderNotConfigured:'provider_not_configured'},",
+      "it2={Cancelled:'cancelled',NetworkError:'network_error',AuthFailed:'auth_failed',ServerError:'server_error',Unknown:'unknown'},",
+      "nn2={NetworkError:'network_error',AuthRefresh:'auth_refresh',ServerError:'server_error'},",
+      "SS=new Set(['provider_overloaded']);",
+      "function jV(e){return!1}",
+      "function pu2(e){return e}",
+      "function s$(e){let t=e,r=new WeakSet;for(;t&&typeof t==='object'&&!r.has(t);){r.add(t);if(typeof t.statusCode==='number')return t.statusCode;t=t.cause}}",
+      "function p_(e){return}",
+      "function hdr2(e){return}",
+      "function ddr2(e,t){return!1}",
+      "function U_e2(e){return!1}",
+      "function Ob2(e){return e&&typeof e==='object'?e:void 0}",
+      "function d1o2(e){let t=e?.trim().toUpperCase();return t==='ECONNRESET'||t==='EPIPE'||t==='CONNECTIONCLOSED'}",
+      "function fdr2(e){return!1}",
+      "function Mye2(e){return e.retryable&&e.reason!==it2.Cancelled}",
+      "function oO(e,t){return e===null||typeof e!==\"object\"?!1:t.has(e)?!0:(t.add(e),!1)}",
+      "function pP(e){return e!==null&&typeof e===\"object\"?e:{}}",
+      "function qQ(e,t){let r=e[t];return typeof r===\"string\"&&r.length>0?r:void 0}",
+      "function w$(e){let t=e?.toUpperCase();return t===\"ECONNRESET\"||t===\"ECONNREFUSED\"||t===\"EAI_AGAIN\"||t===\"ENOTFOUND\"||t===\"ENETUNREACH\"||t===\"EHOSTUNREACH\"||t===\"UND_ERR_SOCKET\"||t===\"UND_ERR_CONNECT_TIMEOUT\"}",
+      "function Rq(e){return kq(e,new WeakSet)}",
+      "function kq(e,t){if(oO(e,t))return;let r=pP(e),n=qQ(r,\"code\");if(n)return n;let o=r.cause;if(o&&o!==e)return kq(o,t)}",
+      "function qq(e,t){if(t){if(w$(t)||SS.has(t))return!0;let r=t.toLowerCase();if(r===\"network_error\"||r===\"network_error_retryable\")return!0}return jV(e)}",
+      "function Wb(e,t){let r=pu2(e),n=s$(r),o=Rq(r),i=p_(r),a=hdr2(i);",
+      "if(ddr2(r,t))return{code:yt2.ModelRequestFailed,message:'cancelled',reason:it2.Cancelled,retryReason:nn2.NetworkError,retryable:!1,statusCode:n};",
+      "if(n===401||n===403)return{code:yt2.ProviderNotConfigured,message:'auth failed',reason:it2.AuthFailed,retryReason:nn2.AuthRefresh,retryable:!1,statusCode:n};",
+      "if(w$(o))return{code:yt2.ModelRequestFailed,message:\"Network connection failed for the provider request.\",reason:it2.NetworkError,retryReason:nn2.NetworkError,retryable:!0,retryAfterMs:a,statusCode:n};",
+      "let d=fdr2(r);return{code:yt2.ModelRequestFailed,message:'Model request failed.',reason:d?it2.ServerError:it2.Unknown,retryReason:d?nn2.ServerError:nn2.NetworkError,retryable:d,statusCode:n}}",
+      "function s9o(e,t){let r=pu2(e);if(U_e2(r)||d1o2(Rq(r)))return!0;if(t!==void 0)return!1;let n=Ob2(r)?.providerCode;return d1o2(typeof n==\"number\"?String(n):n)}",
+      "function z9o(e){return e.emittedRetryBoundaryEvent||e.attempt>=e.maxAttempts||e.failure.reason===it2.Cancelled?!1:e.preserveProviderStreamBoundaries===!0&&s9o(e.error,e.httpResponseStatus)?!0:Mye2(e.failure)?e.preserveProviderStreamBoundaries!==!0||e.streamFailurePhase!==\"response_body\":!1}",
+      "function* walk(e){let t=e,r=new WeakSet;for(let n=0;n<=6;n+=1){if(!t||typeof t!=='object'||r.has(t))return;r.add(t);yield t;t=t.cause}}",
+      "function recoverable(e){for(let t of walk(e)){if(t.retryable===!0)return!0;let r=pP(t.context);if(r.retryable===!0)return!0}return!1}"
+    ].join("");
+    const patched = patchRuntimeNetworkRetryClassification(runtime);
+
+    expect(hasRuntimeNetworkRetryGuard(runtime)).toBe(false);
+    expect(hasRuntimeNetworkRetryGuard(patched)).toBe(true);
+    expect(patched).toContain("function $zTransportChain(e,t){");
+    expect(patched).toContain("return e.emittedRetryBoundaryEvent||e.attempt>=e.maxAttempts");
+    expect(patched).not.toContain("e.emittedRetryBoundaryEvent&&!$zTransportChain");
+    expect(() => new Function(patched)).not.toThrow();
+    expect(patchRuntimeNetworkRetryClassification(patched)).toBe(patched);
+    expect(() => patchRuntimeNetworkRetryClassification("incompatible runtime")).toThrow(/incompatible/);
+
+    const load = new Function(
+      `${patched};return {classify:Wb,decide:qq,gate:z9o,recoverable,stale:s9o,transport:e=>$zTransportChain(e,new WeakSet)};`
+    ) as () => {
+      classify: (error: unknown) => {
+        code: string;
+        reason: string;
+        retryable: boolean;
+      };
+      decide: (error: unknown, reason?: string) => boolean;
+      gate: (failure: Record<string, unknown>) => boolean;
+      recoverable: (error: unknown) => boolean;
+      stale: (error: unknown, status?: number) => boolean;
+      transport: (error: unknown) => boolean;
+    };
+    const { classify, decide, gate, recoverable, stale, transport } = load();
+
+    const socket = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const terminated = Object.assign(new TypeError("terminated"), { cause: socket });
+    const wrapped = Object.assign(new Error("Model request failed"), {
+      code: "model_request_failed",
+      cause: terminated
+    });
+    const authorized = Object.assign(new Error("Model request failed"), {
+      code: "model_request_failed",
+      cause: Object.assign(new Error("Unauthorized"), { statusCode: 401, cause: socket })
+    });
+
+    expect(transport(wrapped)).toBe(true);
+    expect(decide(wrapped)).toBe(true);
+    expect(decide({}, "network_error")).toBe(true);
+    expect(classify(wrapped)).toMatchObject({
+      code: "model_request_failed",
+      reason: "network_error",
+      retryable: true
+    });
+    expect(transport(authorized)).toBe(true);
+    expect(classify(authorized).retryable).toBe(false);
+    expect(transport({ cause: { message: "write EPIPE" } })).toBe(true);
+    expect(transport({ cause: { code: "ETIMEDOUT", message: "connect failed" } })).toBe(true);
+    expect(stale(wrapped)).toBe(true);
+
+    const failure = classify(wrapped);
+    const beforeOutput = {
+      emittedRetryBoundaryEvent: false,
+      attempt: 1,
+      maxAttempts: 6,
+      failure,
+      error: wrapped,
+      preserveProviderStreamBoundaries: false
+    };
+    expect(gate(beforeOutput)).toBe(true);
+    expect(gate({ ...beforeOutput, emittedRetryBoundaryEvent: true })).toBe(false);
+    expect(gate({ ...beforeOutput, attempt: 6 })).toBe(false);
+    expect(gate({ ...beforeOutput, failure: { ...failure, reason: "cancelled" } })).toBe(false);
+    expect(recoverable({ cause: wrapped, context: { retryable: failure.retryable } })).toBe(true);
+
+    const cyclic: { code?: string; cause?: unknown } = { code: "model_request_failed" };
+    const cyclicCause: { code?: string; cause?: unknown } = {
+      code: "model_request_failed",
+      cause: cyclic
+    };
+    cyclic.cause = cyclicCause;
+    expect(transport(cyclic)).toBe(false);
+    expect(decide(cyclic)).toBe(false);
   });
 
   test("adds a Desktop authorization-code completion path while retaining official persistence", () => {


### PR DESCRIPTION
Detect transient transport errors hidden behind model_request_failed wrappers.

  Keep the emitted-output retry boundary intact and delegate partial-stream
  recovery to the existing turn-level recovery mechanism to avoid duplicate
  text and tool execution.

  Add synthetic classification coverage and an end-to-end SSE connection-reset
  test.

  Fixes #108