### PR TITLE
fix(tui): prevent functional keys from poisoning picker filters

### DIFF
--- a/packages/zcode-tui/src/choice-dialog.ts
+++ b/packages/zcode-tui/src/choice-dialog.ts
@@ -3,6 +3,7 @@ import {
   Editor,
   getKeybindings,
   Input,
+  isKeyRelease,
   matchesKey,
   SelectList,
   truncateToWidth,
@@ -28,6 +29,78 @@ export interface ChoiceItem extends SelectItem {
 }
 
 const fullscreenDialogContentMaxWidth = 100;
+/** Leading numeric parameter of a Kitty CSI-u sequence: the base key code. */
+const kittyCsiUBaseCodepointPattern = /^\x1b\[(\d+)(?=[:;u])/u;
+const controlCharacterPattern = /[\u0000-\u001f\u007f-\u009f]/u;
+
+/**
+ * Codepoint ranges inside the Unicode private use area that terminals reserve
+ * for keys rather than glyphs:
+ *
+ * - Kitty's keyboard protocol encodes functional keys (F1-F35, PrintScreen,
+ *   CapsLock, media keys, IME process keys, modifiers, …) in 57344-57454.
+ * - macOS/AppKit reports its own function keys as 0xF700-0xF8FF (NSUpArrow­
+ *   FunctionKey … NSModeSwitchFunctionKey), which some terminals pass through
+ *   raw.
+ *
+ * Everything else in the private use area is a real glyph — Nerd Font icons
+ * live just above Kitty's block (Powerline starts at 0xE0A0, Seti at 0xE5FA,
+ * Font Awesome at 0xF000) — so it must stay typeable and pasteable.
+ */
+const functionalKeyRanges = [
+  { start: 57344, end: 57454 },
+  { start: 0xf700, end: 0xf8ff }
+] as const;
+
+function isFunctionalKeyCharacter(character: string): boolean {
+  const codepoint = character.codePointAt(0);
+  if (codepoint === undefined) return false;
+  return functionalKeyRanges.some(({ start, end }) => codepoint >= start && codepoint <= end);
+}
+
+function containsFunctionalKeyCharacter(value: string): boolean {
+  return [...value].some(isFunctionalKeyCharacter);
+}
+
+/**
+ * True when a Kitty CSI-u sequence describes a functional key with no text
+ * equivalent.
+ *
+ * Rather than duplicating pi-tui's functional-key mapping table (which would
+ * silently drift as that table grows), this asks pi-tui to decode the *base*
+ * key code on its own. Numpad keys and friends normalize to real text; anything
+ * that still decodes to a reserved key codepoint has no text equivalent. Testing
+ * the base code also ignores the shifted/alternate fields, which must never
+ * turn a functional key into text.
+ */
+function isTextlessFunctionalKey(data: string): boolean {
+  const match = kittyCsiUBaseCodepointPattern.exec(data);
+  if (!match) return false;
+  const decodedBase = decodeKittyPrintable(`\x1b[${match[1]}u`);
+  return decodedBase === undefined || containsFunctionalKeyCharacter(decodedBase);
+}
+
+/**
+ * Resolve the text a key press should append to the filter, or undefined when
+ * the input is not text and should fall through to list navigation.
+ */
+function decodeFilterText(data: string): string | undefined {
+  if (data.length === 0) return undefined;
+  // Releases never produce text. pi-tui's central dispatch already drops them
+  // for components that do not opt in, but guard here too so direct callers
+  // (and any future opt-in) cannot poison the filter.
+  if (isKeyRelease(data)) return undefined;
+  if (isTextlessFunctionalKey(data)) return undefined;
+  const printable = decodeKittyPrintable(data);
+  if (printable !== undefined) {
+    return containsFunctionalKeyCharacter(printable) ? undefined : printable;
+  }
+  // Legacy/raw input. Some terminals (notably macOS) deliver functional keys as
+  // bare reserved-range characters, so screen those out as well. Ordinary
+  // private-use glyphs (Nerd Font icons) fall through as text.
+  if (controlCharacterPattern.test(data) || containsFunctionalKeyCharacter(data)) return undefined;
+  return data;
+}
 
 class FullscreenDialogSurface implements Component {
   focused = false;
@@ -243,10 +316,9 @@ class ChoiceDialog implements Component {
       return;
     }
 
-    const printable = decodeKittyPrintable(data)
-      ?? (data.length > 0 && !/[\u0000-\u001f\u007f-\u009f]/u.test(data) ? data : undefined);
-    if (printable !== undefined) {
-      this.updateFilter(this.filter + printable);
+    const text = decodeFilterText(data);
+    if (text !== undefined) {
+      this.updateFilter(this.filter + text);
       return;
     }
 

--- a/test/choice-dialog.test.ts
+++ b/test/choice-dialog.test.ts
@@ -133,6 +133,84 @@ describe("TUI choice dialog", () => {
     expect(host.children).toHaveLength(0);
   });
 
+  test("ignores decoded and raw Kitty functional-key text in choice filters", async () => {
+    const root = new Container();
+    const host = new Container();
+    const focusState: { current: Component | null } = { current: null };
+    const ui = {
+      terminal: { rows: 24 },
+      requestRender() {},
+      setFocus(component: Component | null) {
+        focusState.current = component;
+      }
+    } as unknown as TUI;
+    root.addChild(host);
+
+    const pending = choose(ui, host, createTheme(false), {
+      title: "Select model",
+      prompt: "Current model: local/GLM-5.2.",
+      items: [
+        { value: "alpha", label: "Alpha" },
+        { value: "beta", label: "Beta" },
+        { value: "1-model", label: "1 Numpad model" }
+      ]
+    });
+
+    for (const sequence of [
+      "\x1b[57361u", // PrintScreen press
+      "\x1b[57361:51;2u", // PrintScreen with shifted alternate key "3"
+      "\x1b[57362;1:1u", // Pause press with event type
+      "\x1b[57363;1:2u", // Menu repeat
+      "\x1b[57361;1:3u", // PrintScreen release (defensive direct dispatch)
+      "\x1b[101;1:3u", // Letter "e" release must not type (issue #109)
+      "\uE011", // Raw Kitty PrintScreen functional codepoint
+      "\uF72E" // Raw macOS NSPrintScreenFunctionKey codepoint
+    ]) {
+      focusState.current?.handleInput?.(sequence);
+      const output = root.render(80).join("\n");
+      expect(output).toContain("Filter: type to search");
+      expect(output).not.toContain("No matching commands");
+      expect(output).toContain("Alpha");
+      expect(output).toContain("Beta");
+    }
+
+    focusState.current?.handleInput?.("\x1b[57400u");
+    const keypadFiltered = root.render(80).join("\n");
+    expect(keypadFiltered).toContain("Filter: 1");
+    expect(keypadFiltered).toContain("1 Numpad model");
+    expect(keypadFiltered).not.toContain("No matching commands");
+
+    // Nerd Font glyphs sit outside the reserved key ranges and stay typeable.
+    for (const glyph of [
+      "\uE0A0", // Powerline branch
+      "\uE0B0", // Powerline separator
+      "\uE5FA", // Seti
+      "\uF07C", // Font Awesome folder
+      "\uE06F" // Just past Kitty's reserved block (57455)
+    ]) {
+      focusState.current?.handleInput?.("\x15");
+      focusState.current?.handleInput?.(glyph);
+      expect(root.render(80).join("\n")).toContain(`Filter: ${glyph}`);
+    }
+
+    // Held text keys must still repeat; only functional keys and releases are dropped.
+    focusState.current?.handleInput?.("\x15");
+    focusState.current?.handleInput?.("\x1b[98u");
+    focusState.current?.handleInput?.("\x1b[98;1:2u");
+    expect(root.render(80).join("\n")).toContain("Filter: bb");
+
+    focusState.current?.handleInput?.("\x15");
+    focusState.current?.handleInput?.("\x1b[97u");
+    const filtered = root.render(80).join("\n");
+    expect(filtered).toContain("Filter: a");
+    expect(filtered).toContain("Alpha");
+    expect(filtered).not.toContain("Beta");
+
+    focusState.current?.handleInput?.("\x1b");
+    expect(await pending).toBeNull();
+    expect(host.children).toHaveLength(0);
+  });
+
   test("masked prompts return the secret without rendering it", async () => {
     const root = new Container();
     const host = new Container();


### PR DESCRIPTION
With the Kitty keyboard protocol active, every picker that embeds a
  filter box (/resume, /model, ask) could collapse to "No matching
  commands" while navigating. pi-tui's decodeKittyPrintable normalizes
  only the keypad block (57399-57426); every other functional key --
  F1-F35, CapsLock, PrintScreen, Menu, media and IME keys -- falls
  through to String.fromCodePoint and yields an invisible private-use
  glyph. Appending that to the filter made SelectList's startsWith match
  nothing, and the filter line still looked empty.

  - resolve filter text through a single decodeFilterText helper
  - detect textless functional keys by asking pi-tui to decode the CSI-u base key code, instead of duplicating its mapping table, so the guard cannot drift as that table grows
  - testing the base code also ignores the shifted/alternate fields, which must never turn a functional key into text
  - treat only the reserved key ranges as non-text (Kitty 57344-57454 and AppKit 0xF700-0xF8FF) so Nerd Font glyphs stay typeable and pasteable
  - drop key releases up front, so a direct handleInput call cannot type a released letter; held text keys still repeat
  
 Fixes #109