### PR TITLE
fix(tui): recover fullscreen rendering after focus changes

### DIFF
--- a/packages/zcode-tui/src/index.ts
+++ b/packages/zcode-tui/src/index.ts
@@ -307,6 +307,7 @@ const runtimeCommandSummaries = new Map([
 const terminalThemeQueryTimeoutMs = 100;
 const exitUsageQueryTimeoutMs = 250;
 const fullscreenWelcomeTransitionMs = 180;
+const terminalFocusIn = "\x1b[I";
 const updateAvailableBlockId = "update_available";
 const modelRetryBlockIdPrefix = "model_retry_status";
 const questionBackValue = "__back__";
@@ -523,6 +524,16 @@ class ZCodeAltScreen extends TuiAltScreen {
     this.currentInput = data;
   }
 
+  /**
+   * The terminal can lose visible rows while this process is unfocused even
+   * though pi-tui's logical frame remains unchanged. Invalidate its
+   * differential cache so the next frame repaints every row.
+   */
+  forceFullRedraw(): void {
+    // Resetting also clears the layout used by mouse events in this input batch.
+    process.nextTick(() => this.requestRender(true));
+  }
+
   protected override isOverlayFocused(): boolean {
     if (super.isOverlayFocused()) return true;
     return this.viewportInputDeferral?.(this.currentInput ?? "") === true;
@@ -533,7 +544,9 @@ class ZCodeAltScreen extends TuiAltScreen {
 class NotifyingProcessTerminal extends ProcessTerminal {
   constructor(
     private readonly beforeInput: (data: string) => void,
-    private readonly afterInput?: () => void
+    private readonly afterInput?: () => void,
+    private readonly onFocusIn?: () => void,
+    private readonly onTerminalResize?: () => void
   ) {
     super();
   }
@@ -545,8 +558,12 @@ class NotifyingProcessTerminal extends ProcessTerminal {
         onInput(data);
       } finally {
         this.afterInput?.();
+        if (data === terminalFocusIn) this.onFocusIn?.();
       }
-    }, onResize);
+    }, () => {
+      onResize();
+      this.onTerminalResize?.();
+    });
   }
 }
 
@@ -708,7 +725,8 @@ class ZCodeTui {
     this.tuiMode = resolveTuiMode(process.env, { ui: { tuiMode: options.initialTuiMode } });
     this.ui = this.createTui(this.tuiMode);
     this.notifications = new TurnNotifier({
-      writeTerminal: (data) => this.ui.terminal.write(data)
+      writeTerminal: (data) => this.ui.terminal.write(data),
+      focusReportingRequired: this.tuiMode === "fullscreen"
     });
     this.status = new StatusLine();
     this.turnStatus = new FooterBar();
@@ -783,6 +801,7 @@ class ZCodeTui {
       if (effective !== this.tuiMode) {
         this.ui = this.createTui(effective);
         this.tuiMode = effective;
+        this.notifications.setFocusReportingRequired(effective === "fullscreen");
         this.editor = this.createEditor(this.ui);
       }
     } catch {
@@ -928,7 +947,9 @@ class ZCodeTui {
     const terminal = new NotifyingProcessTerminal((data) => {
       fullscreenTui?.setCurrentInput(data);
       this.notifications?.handleInput(data);
-    }, () => fullscreenTui?.setCurrentInput(undefined));
+    }, () => fullscreenTui?.setCurrentInput(undefined),
+    () => fullscreenTui?.forceFullRedraw(),
+    () => fullscreenTui?.forceFullRedraw());
     if (mode !== "fullscreen") return new TuiMainScreen(terminal, true);
 
     const tui = new ZCodeAltScreen(terminal, true, undefined, {
@@ -1139,6 +1160,7 @@ class ZCodeTui {
       this.ui.stop({ preserveScreen: true });
       this.ui = this.createTui(next);
       this.tuiMode = next;
+      this.notifications.setFocusReportingRequired(next === "fullscreen");
       this.sessionHasContent = hadSessionContent;
       this.fullscreenWelcomeVisible = !hadSessionContent;
       this.fullscreenHeader.setPhase(hadSessionContent ? "rail" : "welcome");
@@ -1168,6 +1190,7 @@ class ZCodeTui {
         }
         this.ui = previousUi;
         this.tuiMode = previousMode;
+        this.notifications.setFocusReportingRequired(previousMode === "fullscreen");
         this.sessionHasContent = hadSessionContent;
         this.fullscreenWelcomeVisible = previousMode === "fullscreen" ? !hadSessionContent : true;
         this.fullscreenHeader.setPhase(hadSessionContent ? "rail" : "welcome");

--- a/packages/zcode-tui/src/notifications.ts
+++ b/packages/zcode-tui/src/notifications.ts
@@ -48,6 +48,8 @@ type ExecutableResolver = (name: string) => string | null;
 
 interface TurnNotifierOptions {
   writeTerminal: (data: string) => void;
+  /** Keep terminal focus reports enabled for fullscreen redraw recovery. */
+  focusReportingRequired?: boolean;
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   nativeNotify?: NativeNotificationSender;
@@ -276,6 +278,7 @@ export class TurnNotifier {
   private settings: NotificationSettings;
   private active = false;
   private focusReporting = false;
+  private focusReportingRequired: boolean;
   private terminalFocus: TerminalFocusState = "unknown";
   private terminalUnavailable = false;
 
@@ -286,6 +289,7 @@ export class TurnNotifier {
       sendNativeNotification(platform, title, body, this.env)
     ));
     this.settings = options.settings ?? notificationSettings(this.env);
+    this.focusReportingRequired = options.focusReportingRequired === true;
   }
 
   start(): void {
@@ -315,6 +319,12 @@ export class TurnNotifier {
   setSettings(settings: NotificationSettings): void {
     if (this.settings.condition !== settings.condition) this.terminalFocus = "unknown";
     this.settings = { ...settings };
+    this.syncFocusReporting();
+  }
+
+  setFocusReportingRequired(required: boolean): void {
+    if (this.focusReportingRequired === required) return;
+    this.focusReportingRequired = required;
     this.syncFocusReporting();
   }
 
@@ -386,8 +396,10 @@ export class TurnNotifier {
   private syncFocusReporting(): void {
     if (
       !this.active ||
-      this.settings.method === "off" ||
-      this.settings.condition !== "unfocused"
+      (!this.focusReportingRequired && (
+        this.settings.method === "off" ||
+        this.settings.condition !== "unfocused"
+      ))
     ) {
       this.disableFocusReporting();
       return;

--- a/scripts/smoke-tui-fullscreen-layout.ts
+++ b/scripts/smoke-tui-fullscreen-layout.ts
@@ -98,9 +98,13 @@ async function runPhase(options: { copyOnSelect: boolean }): Promise<void> {
     if (copyRow < 0 || copyColumn < 0) {
       throw new Error(`Could not locate fullscreen text for mouse-copy verification.\n${startupRows.join("\n")}`);
     }
-    terminal.write(`\x1b[<0;${copyColumn + 1};${copyRow + 1}M`);
-    terminal.write(`\x1b[<32;${copyColumn + 4};${copyRow + 1}M`);
-    terminal.write(`\x1b[<0;${copyColumn + 4};${copyRow + 1}m`);
+    // Focus and the first mouse gesture can arrive in a single input batch.
+    terminal.write(
+      "\x1b[O\x1b[I"
+      + `\x1b[<0;${copyColumn + 1};${copyRow + 1}M`
+      + `\x1b[<32;${copyColumn + 4};${copyRow + 1}M`
+      + `\x1b[<0;${copyColumn + 4};${copyRow + 1}m`
+    );
     if (options.copyOnSelect) {
       await waitFor(/Copied!/i);
       const copiedText = await Bun.file(clipboardPath).text();

--- a/scripts/smoke-tui-fullscreen.ts
+++ b/scripts/smoke-tui-fullscreen.ts
@@ -36,7 +36,8 @@ const child = Bun.spawn([process.execPath, fixture], {
     TERM: "xterm-256color",
     TERM_PROGRAM: "iTerm.app",
     ZCODE_APP_CLI_EXECUTABLE: process.execPath,
-    ZCODE_APP_CLI_ENTRY: fixture
+    ZCODE_APP_CLI_ENTRY: fixture,
+    ZCODE_TUI_NOTIFICATION_METHOD: "off"
   },
   terminal
 });
@@ -75,8 +76,15 @@ let interactionError: unknown;
 try {
   // P1-1: config-persisted fullscreen mode takes effect on startup.
   await waitFor("alternate screen enter (config-driven)", /\x1b\[\?1049h/);
+  await waitFor("fullscreen focus reporting", /\x1b\[\?1004h/);
   await waitForPlain("welcome banner", /ZCode/i);
   await waitForPlain("interactive editor", /alpha\/model/i);
+  // Terminal tabs can lose visible rows without changing the logical frame or
+  // geometry. Focus-in must invalidate pi-tui's differential cache so the
+  // complete fullscreen frame is painted again.
+  const focusRecoveryStart = output.length;
+  terminal.write("\x1b[O\x1b[I");
+  await waitFor("fullscreen focus recovery repaint", /\x1b\[\?2026h\x1b\[2J[\s\S]*alpha\/model/i, focusRecoveryStart);
   // The editor must be constructed against the config-selected fullscreen TUI,
   // so delayed autocomplete repaints without a follow-up key.
   const completionStart = output.length;

--- a/test/notifications.test.ts
+++ b/test/notifications.test.ts
@@ -200,6 +200,22 @@ describe("TUI turn notifications", () => {
     expect(writes).toEqual(["\x1b[?1004h", "\x1b[?1004l", "\x1b[?1004h"]);
   });
 
+  test("keeps focus reporting for fullscreen redraws when notifications are off", () => {
+    const writes: string[] = [];
+    const notifier = new TurnNotifier({
+      settings: { method: "off", condition: "always" },
+      focusReportingRequired: true,
+      writeTerminal: (data) => writes.push(data)
+    });
+
+    notifier.start();
+    notifier.setSettings({ method: "off", condition: "unfocused" });
+    expect(writes).toEqual(["\x1b[?1004h"]);
+
+    notifier.setFocusReportingRequired(false);
+    expect(writes).toEqual(["\x1b[?1004h", "\x1b[?1004l"]);
+  });
+
   test("uses Codex-style BEL fallback in Apple Terminal without requiring focus support", async () => {
     let nativeCalls = 0;
     const writes: string[] = [];


### PR DESCRIPTION
  - defer full redraw until the current input batch completes
  - keep focus reporting enabled in fullscreen mode
  - handle resize recovery and add regression coverage