### PR TITLE
fix: preflight keyless prompts without losing queued input

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,5 +1,20 @@
 # Configuration
 
+## Prompt Access Preflight
+
+Ordinary TUI input and new headless `--prompt`, `--print`, `-p`, and `--target`
+requests diagnose a clearly keyless Z.AI/BigModel Coding Plan configuration
+before starting a model turn. The TUI restores rejected input to an empty editor,
+or retains it in the follow-up queue without replacing a newer draft. Rejected
+queued input keeps its position and metadata; auto-send pauses until user action.
+Headless commands exit unsuccessfully with setup instructions.
+
+This is deliberately not a general credentials validator. Custom endpoints,
+environment authentication/model overrides, ancestor project configurations,
+dotenv files, and resumed headless sessions remain the runtime's responsibility.
+Login, setup, help, and other management commands remain available. No credentials
+are printed, changed, or tested over the network by this check.
+
 This document covers the detailed model-access configuration for
 zcode-app-cli. For installation and basic usage, see the
 [main README](../README.md).

--- a/packages/zcode-tui/src/index.ts
+++ b/packages/zcode-tui/src/index.ts
@@ -3,6 +3,8 @@ import { appendFileSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import { basename } from "node:path";
 
+import { missingCodingPlanKey } from "../../../src/prompt-preflight.ts";
+import { preflightSubmission } from "./prompt-preflight.ts";
 import {
   clearSetupPending,
   readConfiguredModelAccess,
@@ -1522,6 +1524,24 @@ class ZCodeTui {
     const input = (queuedSubmission?.input ?? rawInput).trim();
     if (!input || this.stopped) return false;
     const submission = queuedSubmission ?? protectSubmission(input);
+    if (!input.startsWith("/") && !this.primaryTurnActive) {
+      const allowed = await preflightSubmission({
+        validate: () => missingCodingPlanKey({
+          model: this.model,
+          workingDirectory: this.options.workspaceDirectory
+        }),
+        isStopped: () => this.stopped,
+        submission,
+        queued: queuedSubmission !== undefined,
+        editor: {
+          getText: () => this.editor.getText(),
+          setText: (text) => this.editor.setText(text)
+        },
+        inputQueue: this.inputQueue,
+        warn: (message) => this.addNotice(message, "warning")
+      });
+      if (!allowed) return false;
+    }
     if (submission.recordHistory) {
       this.rememberEditorHistory(input);
       this.editor.addToHistory(input);

--- a/packages/zcode-tui/src/input-queue.ts
+++ b/packages/zcode-tui/src/input-queue.ts
@@ -62,6 +62,12 @@ export class InputQueue {
     return submission;
   }
 
+  restoreFollowUp(submission: QueuedSubmission): void {
+    this.queuedFollowUps.unshift(submission);
+    this.autoSendEnabled = false;
+    this.syncView();
+  }
+
   editLatestFollowUp(): QueuedSubmission | undefined {
     const submission = this.queuedFollowUps.pop();
     if (submission) this.syncView();

--- a/packages/zcode-tui/src/prompt-preflight.ts
+++ b/packages/zcode-tui/src/prompt-preflight.ts
@@ -1,0 +1,25 @@
+import type { InputQueue, QueuedSubmission } from "./input-queue.ts";
+
+/** Preserve rejected input without replacing a draft typed during validation. */
+export async function preflightSubmission(options: {
+  validate(): Promise<string | undefined>;
+  isStopped(): boolean;
+  submission: QueuedSubmission;
+  queued: boolean;
+  editor: { getText(): string; setText(text: string): void };
+  inputQueue: InputQueue;
+  warn(message: string): void;
+}): Promise<boolean> {
+  const diagnostic = await options.validate();
+  if (options.isStopped()) return false;
+  if (!diagnostic) return true;
+
+  if (options.queued || options.editor.getText() !== "") {
+    options.inputQueue.restoreFollowUp(options.submission);
+  } else {
+    options.editor.setText(options.submission.input);
+    options.inputQueue.autoSend = false;
+  }
+  options.warn(diagnostic);
+  return false;
+}

--- a/scripts/smoke-prompt-preflight-races.ts
+++ b/scripts/smoke-prompt-preflight-races.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = await mkdtemp(join(tmpdir(), "zcode-preflight-races-"));
+let output = "";
+const decoder = new TextDecoder();
+const terminal = new Bun.Terminal({
+  cols: 120, rows: 35,
+  data(terminal, data) {
+    const text = decoder.decode(data, { stream: true });
+    output += text;
+    if (text.includes("\x1b[6n")) terminal.write("\x1b[1;1R");
+  }
+});
+const child = Bun.spawn([process.execPath, join(import.meta.dir, "../test/fixtures/tui-preflight-races.ts")], {
+  cwd: home,
+  env: { PATH: process.env.PATH, HOME: home, USERPROFILE: home, TERM: "xterm-256color", CI: "1" },
+  terminal
+});
+async function waitFor(predicate: () => boolean | Promise<boolean>, label: string) {
+  const deadline = Date.now() + 5_000;
+  while (child.exitCode === null && Date.now() < deadline) {
+    if (await predicate()) return;
+    await Bun.sleep(20);
+  }
+  throw new Error(`Missing ${label}: ${output.slice(-2000)}`);
+}
+const events = async () => (await readFile(join(home, "events.jsonl"), "utf8").catch(() => ""))
+  .trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+try {
+  await waitFor(() => output.includes("glm-5.3-flash"), "editor");
+  terminal.write("original input\r");
+  await waitFor(async () => (await events()).some(event => event.check === 1), "pending validation");
+  terminal.write("newer draft");
+  await Bun.sleep(100);
+  await writeFile(join(home, "release"), "");
+  await waitFor(() => output.includes("PREFLIGHT_REJECTED_1"), "first rejection");
+  terminal.write("\r");
+  await waitFor(() => output.includes("PREFLIGHT_REJECTED_3"), "queued rejection");
+  assert.deepEqual((await events()).filter(event => event.submitted).map(event => event.submitted), ["newer draft"]);
+  terminal.write("retry trigger\r");
+  await waitFor(async () => (await events()).filter(event => event.submitted).length === 3, "retained queue retry");
+  assert.deepEqual((await events()).filter(event => event.submitted).map(event => event.submitted),
+    ["newer draft", "retry trigger", "original input"]);
+  terminal.write("/exit\r");
+  await Promise.race([child.exited, Bun.sleep(2_000)]);
+  assert.equal(child.exitCode, 0);
+  console.log("PASS: actual TUI preserves newer draft and rejected queued input; zero model calls");
+} finally {
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await child.exited;
+  terminal.close();
+  await rm(home, { recursive: true, force: true });
+}

--- a/scripts/smoke-prompt-preflight.ts
+++ b/scripts/smoke-prompt-preflight.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = await mkdtemp(join(tmpdir(), "zcode-keyless-tui-"));
+await mkdir(join(home, ".zcode", "cli"), { recursive: true });
+await writeFile(join(home, ".zcode", "cli", "config.json"), JSON.stringify({
+  provider: { zai: { kind: "anthropic", options: {
+    apiKeyRequired: true, baseURL: "https://api.z.ai/api/anthropic"
+  } } },
+  model: { main: "zai/glm-5.3-flash" }
+}));
+
+let output = "";
+const decoder = new TextDecoder();
+const terminal = new Bun.Terminal({
+  cols: 120, rows: 35,
+  data(_terminal, data) { output += decoder.decode(data, { stream: true }); }
+});
+const child = Bun.spawn([process.execPath, join(import.meta.dir, "../test/fixtures/tui-keyless.ts")], {
+  cwd: home,
+  env: {
+    PATH: process.env.PATH, HOME: home, USERPROFILE: home, TERM: "xterm-256color", CI: "1",
+    ZCODE_BASE_URL: "https://zcode.z.ai", ZCODE_MODEL_RETRY_MAX_RETRIES: "5"
+  },
+  terminal
+});
+async function waitFor(text: string) {
+  const deadline = Date.now() + 5_000;
+  while (!output.includes(text) && child.exitCode === null && Date.now() < deadline) await Bun.sleep(25);
+  assert(output.includes(text), `Missing ${text}: ${output.slice(-2000)}`);
+}
+try {
+  await waitFor("glm-5.3-flash");
+  terminal.write("offline fixture input\r");
+  await waitFor("No model request was sent");
+  assert(!output.includes("UNEXPECTED_MODEL_SUBMISSION"));
+  terminal.write("\x15/exit\r");
+  await Promise.race([child.exited, Bun.sleep(2_000)]);
+  assert.equal(child.exitCode, 0);
+  console.log("PASS: actual TUI rejects keyless Flash input before submitPrompt; zero model requests");
+} finally {
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await child.exited;
+  terminal.close();
+  await rm(home, { recursive: true, force: true });
+}

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -27,6 +27,7 @@ import {
 } from "./zai-oauth.ts";
 import { requestAppServer } from "./app-server-client.ts";
 import { runPluginCommand } from "./plugin-cli.ts";
+import { missingCodingPlanKey } from "./prompt-preflight.ts";
 import {
   capabilitiesFromExtractionMetadata,
   type RuntimeCliOptionType
@@ -149,6 +150,8 @@ interface RuntimeInvocationInspection {
   explicitBrowserUse: boolean;
   invalid: boolean;
   passthrough: boolean;
+  workingDirectory?: string;
+  resume: boolean;
 }
 
 function inspectRuntimeInvocation(
@@ -161,6 +164,8 @@ function inspectRuntimeInvocation(
   let invalid = false;
   let passthrough = false;
   let presentationSurface = false;
+  let workingDirectory: string | undefined;
+  let resume = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index]!;
@@ -171,6 +176,9 @@ function inspectRuntimeInvocation(
     if (argument.startsWith("--")) {
       const option = longOptionName(argument);
       const inlineValue = option.length !== argument.length;
+      if (option === "--cwd") workingDirectory = inlineValue
+        ? argument.slice(option.length + 1) : args[index + 1];
+      if (option === "--resume" || option === "--continue") resume = true;
       if (option === "--browser-use") {
         explicitBrowserUse = true;
         if (!inlineValue) {
@@ -230,7 +238,10 @@ function inspectRuntimeInvocation(
         }
         continue;
       }
-      if (argument === "-c" || argument === "-f") continue;
+      if (argument === "-c" || argument === "-f") {
+        if (argument === "-c") resume = true;
+        continue;
+      }
       invalid = true;
       continue;
     }
@@ -242,7 +253,17 @@ function inspectRuntimeInvocation(
     && command !== "app-server"
     && command !== "agent-server") invalid = true;
 
-  return { agentInvocation, command, explicitBrowserUse, invalid, passthrough };
+  return { agentInvocation, command, explicitBrowserUse, invalid, passthrough, workingDirectory, resume };
+}
+
+export async function promptPreflight(
+  args: string[], env: NodeJS.ProcessEnv = process.env
+): Promise<string | undefined> {
+  const invocation = inspectRuntimeInvocation(args, readRuntimeCliOptionTypes());
+  if (!invocation.agentInvocation || invocation.invalid || invocation.passthrough || invocation.resume) {
+    return undefined;
+  }
+  return missingCodingPlanKey({ env, workingDirectory: invocation.workingDirectory });
 }
 
 export function withDefaultBrowserUse(
@@ -540,6 +561,11 @@ export async function main(args: string[]): Promise<number> {
   }
 
   try {
+    const diagnostic = await promptPreflight(login.args);
+    if (diagnostic) {
+      console.error(diagnostic);
+      return 1;
+    }
     const runtimeArgs = withDefaultBrowserUse(login.args);
     return await runRuntime(node, runtimeArgs, firstRunSetupEnv(setupPending, runtimeArgs));
   } catch (error) {

--- a/src/prompt-preflight.ts
+++ b/src/prompt-preflight.ts
@@ -1,0 +1,69 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { userConfigPath } from "./model-access.ts";
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    // An unreadable override is also a reason to defer to the runtime.
+    return (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+}
+
+/** Diagnose only unambiguous keyless Coding Plan configs, not general model access. */
+export async function missingCodingPlanKey(options: {
+  env?: NodeJS.ProcessEnv;
+  workingDirectory?: string;
+  model?: string;
+} = {}): Promise<string | undefined> {
+  const env = options.env ?? process.env;
+  if (Object.entries(env).some(([key, value]) => value?.trim()
+    && key !== "ZCODE_BASE_URL" && !key.startsWith("ZCODE_MODEL_RETRY_")
+    && key !== "ZCODE_MODEL_TELEMETRY_ENABLED"
+    && /^(?:ZCODE|ZAI|BIGMODEL|ZHIPU|ANTHROPIC)_.*(?:KEY|TOKEN|MODEL|CONFIG|PROVIDER|BASE_URL)/u.test(key))) {
+    return undefined;
+  }
+  let directory = resolve(options.workingDirectory ?? process.cwd());
+  while (true) {
+    if ((await Promise.all([
+      join(directory, "zcode.json"),
+      join(directory, ".zcode", "config.json"),
+      join(directory, ".env")
+    ].map(exists))).some(Boolean)) return undefined;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  let config: Record<string, unknown> | undefined;
+  try {
+    config = record(JSON.parse(await readFile(userConfigPath(env), "utf8")));
+  } catch {
+    return undefined;
+  }
+  const model = options.model ?? record(config?.model)?.main;
+  if (typeof model !== "string") return undefined;
+  const providerId = model.split("/", 1)[0];
+  if (providerId !== "zai" && providerId !== "bigmodel") return undefined;
+  const provider = record(record(config?.provider)?.[providerId]);
+  const settings = record(provider?.options);
+  const expectedUrl = providerId === "zai"
+    ? "https://api.z.ai/api/anthropic"
+    : "https://open.bigmodel.cn/api/anthropic";
+  if (provider?.kind !== "anthropic" || settings?.baseURL !== expectedUrl
+    || settings?.apiKeyRequired !== true
+    || (typeof settings.apiKey === "string" && settings.apiKey.trim())
+    || (settings.apiKey !== undefined && typeof settings.apiKey !== "string")
+    || Object.keys(record(provider.headers) ?? {}).length > 0) return undefined;
+  return `Model access is not configured for ${providerId}. Run /login or /setup in zcode, `
+    + "or configure its API key before sending a prompt. No model request was sent.";
+}

--- a/test/fixtures/tui-keyless.ts
+++ b/test/fixtures/tui-keyless.ts
@@ -1,0 +1,10 @@
+import { runTui } from "../../packages/zcode-tui/src/index.ts";
+
+await runTui({
+  initialModel: "zai/glm-5.3-flash",
+  initialThoughtLevel: "low",
+  workspaceDirectory: process.env.HOME,
+  submitPrompt: async () => {
+    throw new Error("UNEXPECTED_MODEL_SUBMISSION");
+  }
+});

--- a/test/fixtures/tui-preflight-races.ts
+++ b/test/fixtures/tui-preflight-races.ts
@@ -1,0 +1,28 @@
+import { mock } from "bun:test";
+import { appendFile, access } from "node:fs/promises";
+import { join } from "node:path";
+
+const home = process.env.HOME!;
+const events = join(home, "events.jsonl");
+let checks = 0;
+mock.module("../../src/prompt-preflight.ts", () => ({
+  missingCodingPlanKey: async () => {
+    const check = ++checks;
+    await appendFile(events, JSON.stringify({ check }) + "\n");
+    if (check === 1) {
+      while (!await access(join(home, "release")).then(() => true, () => false)) await Bun.sleep(10);
+    }
+    return check === 1 || check === 3 ? `PREFLIGHT_REJECTED_${check}` : undefined;
+  }
+}));
+
+const { runTui } = await import("../../packages/zcode-tui/src/index.ts");
+await runTui({
+  initialModel: "zai/glm-5.3-flash",
+  initialThoughtLevel: "low",
+  workspaceDirectory: home,
+  submitPrompt: async input => {
+    await appendFile(events, JSON.stringify({ submitted: input }) + "\n");
+    return { response: "OFFLINE_MOCK_RESPONSE" };
+  }
+});

--- a/test/launcher-runtime.test.ts
+++ b/test/launcher-runtime.test.ts
@@ -44,6 +44,24 @@ async function run(args: string[], input = "", environment: Record<string, strin
 }
 
 describe("launcher/runtime integration", () => {
+  test("rejects a keyless prompt before starting the runtime or creating a session", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "zcode-keyless-prompt-"));
+    const fakeNode = join(directory, "fake-node");
+    await writeFile(fakeNode, "#!/bin/sh\nprintf 'RUNTIME_STARTED'\nexit 99\n");
+    await chmod(fakeNode, 0o755);
+    try {
+      const result = await run(["--cwd", directory, "--prompt", "offline test"], "", {
+        HOME: directory, USERPROFILE: directory, ZCODE_NODE: fakeNode, ANTHROPIC_API_KEY: ""
+      });
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("No model request was sent");
+      expect(result.stdout).not.toContain("RUNTIME_STARTED");
+      expect(await Bun.file(join(directory, ".zcode", "cli", "db", "db.sqlite")).exists()).toBe(false);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   test("keeps TUI runtime diagnostics out of the interactive terminal", async () => {
     const directory = await mkdtemp(join(tmpdir(), "zcode-launcher-stderr-"));
     const fakeNode = join(directory, "fake-node");
@@ -79,7 +97,10 @@ describe("launcher/runtime integration", () => {
       expect(failed.stderr).toContain(`Diagnostics: ${logPath}`);
       expect(failed.stderr).not.toContain("ProviderBusinessError");
 
-      const print = await run(["--print", "hello"], "", { ZCODE_NODE: fakeNode });
+      const print = await run(["--print", "hello"], "", {
+        ZCODE_NODE: fakeNode,
+        ANTHROPIC_API_KEY: "fixture-only-key"
+      });
       expect(print.code).toBe(0);
       expect(print.stderr).toContain("ProviderBusinessError");
     } finally {

--- a/test/prompt-preflight.test.ts
+++ b/test/prompt-preflight.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { missingCodingPlanKey } from "../src/prompt-preflight.ts";
+import { promptPreflight } from "../src/launcher.ts";
+import { userConfigPath } from "../src/model-access.ts";
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const home = await mkdtemp(join(tmpdir(), "zcode-preflight-"));
+  directories.push(home);
+  const env = { HOME: home, USERPROFILE: home };
+  const file = userConfigPath(env);
+  const config = {
+    provider: {
+      zai: {
+        kind: "anthropic", models: { "glm-5.3-flash": {} },
+        options: { apiKeyRequired: true, baseURL: "https://api.z.ai/api/anthropic", apiKey: "" },
+        headers: {} as Record<string, string>
+      }
+    },
+    model: { main: "zai/glm-5.3-flash" }
+  };
+  await mkdir(dirname(file), { recursive: true });
+  const save = () => writeFile(file, JSON.stringify(config));
+  await save();
+  return { home, env, file, config, save, options: { env, workingDirectory: home } };
+}
+
+describe("prompt credential preflight (offline)", () => {
+  test("rejects a keyless Coding Plan without altering configuration", async () => {
+    const f = await fixture();
+    const before = await readFile(f.file, "utf8");
+    expect(await missingCodingPlanKey(f.options)).toContain("No model request was sent");
+    expect(await readFile(f.file, "utf8")).toBe(before);
+  });
+
+  test("permits configured keys and auth headers without revealing them", async () => {
+    const f = await fixture();
+    f.config.provider.zai.options.apiKey = "private-fixture-key";
+    await f.save();
+    expect(await missingCodingPlanKey(f.options)).toBeUndefined();
+    f.config.provider.zai.options.apiKey = "";
+    f.config.provider.zai.headers.Authorization = "Bearer private-fixture-token";
+    await f.save();
+    expect(await missingCodingPlanKey(f.options)).toBeUndefined();
+  });
+
+  test("defers environment credentials and model overrides to the runtime", async () => {
+    const f = await fixture();
+    for (const key of ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ZCODE_API_KEY", "ZCODE_MODEL_MAIN"]) {
+      expect(await missingCodingPlanKey({ ...f.options, env: { ...f.env, [key]: "fixture" } })).toBeUndefined();
+    }
+    expect(await missingCodingPlanKey({ ...f.options, env: { ...f.env, ANTHROPIC_API_KEY: "  " } })).toBeDefined();
+    expect(await missingCodingPlanKey({ ...f.options, env: {
+      ...f.env, ZCODE_BASE_URL: "https://zcode.z.ai", ZCODE_MODEL_RETRY_MAX_RETRIES: "5",
+      ZCODE_MODEL_TELEMETRY_ENABLED: "0"
+    } })).toBeDefined();
+  });
+
+  test("does not block a session's different model, OAuth provider, or custom endpoint", async () => {
+    const f = await fixture();
+    for (const model of ["bigmodel/glm-5.3-flash", "builtin:bigmodel-start-plan/GLM-5.3-Flash", "default"]) {
+      expect(await missingCodingPlanKey({ ...f.options, model })).toBeUndefined();
+    }
+    f.config.provider.zai.options.baseURL = "http://localhost:8000";
+    await f.save();
+    expect(await missingCodingPlanKey(f.options)).toBeUndefined();
+  });
+
+  test("defers project and dotenv overrides in parent directories", async () => {
+    const f = await fixture();
+    const child = join(f.home, "child");
+    await mkdir(child);
+    for (const relative of ["zcode.json", ".zcode/config.json", ".env"]) {
+      const override = join(f.home, relative);
+      await writeFile(override, "{}");
+      expect(await missingCodingPlanKey({ ...f.options, workingDirectory: child })).toBeUndefined();
+      await rm(override);
+    }
+  });
+
+  test("leaves malformed configuration to the runtime's own diagnostics", async () => {
+    const f = await fixture();
+    for (const json of ["null", "[]", "invalid", '{"provider":null}']) {
+      await writeFile(f.file, json);
+      expect(await missingCodingPlanKey(f.options)).toBeUndefined();
+    }
+  });
+
+  test("covers headless prompt forms while preserving help, login and resume", async () => {
+    const f = await fixture();
+    for (const args of [["--prompt", "hello"], ["--prompt=hello"], ["--print", "hello"], ["-p", "hello"], ["--target", "hello"]]) {
+      expect(await promptPreflight(["--cwd", f.home, ...args], f.env)).toBeDefined();
+    }
+    for (const args of [["--help"], ["login"], ["tui"], ["doctor"], ["--prompt", "hello", "--help"],
+      ["--prompt", "hello", "--resume", "session"], ["-c", "--prompt", "hello"], ["--prompt", "hello", "--continue"]]) {
+      expect(await promptPreflight([`--cwd=${f.home}`, ...args], f.env)).toBeUndefined();
+    }
+  });
+});

--- a/test/tui-prompt-preflight.test.ts
+++ b/test/tui-prompt-preflight.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { InputQueue, type InputQueueState, type QueuedSubmission } from "../packages/zcode-tui/src/input-queue.ts";
+import { preflightSubmission } from "../packages/zcode-tui/src/prompt-preflight.ts";
+
+function fixture(queued = false) {
+  const states: InputQueueState[] = [];
+  const warnings: string[] = [];
+  const inputQueue = new InputQueue({
+    onStateChanged: state => states.push(state),
+    onSteerCommitted() {}, onSteerDiscarded() {}
+  });
+  const submission: QueuedSubmission = {
+    input: "original prompt", displayInput: "original prompt", secrets: [],
+    recordHistory: !queued,
+    ...(queued ? { pendingInputIds: ["pending_1"], pendingInputReservationId: "reservation_1" } : {})
+  };
+  const state = { draft: "", stopped: false };
+  let finish!: (diagnostic: string | undefined) => void;
+  const validation = new Promise<string | undefined>(resolve => { finish = resolve; });
+  const options = {
+    validate: () => validation,
+    isStopped: () => state.stopped,
+    submission, queued, inputQueue,
+    editor: { getText: () => state.draft, setText: (text: string) => { state.draft = text; } },
+    warn: (message: string) => { warnings.push(message); }
+  };
+  return { options, state, finish, states, warnings };
+}
+
+describe("TUI prompt preflight input preservation", () => {
+  test("restores a popped follow-up at the front with metadata and auto-send paused", async () => {
+    const f = fixture(true);
+    const { inputQueue, submission } = f.options;
+    const second = { ...submission, input: "second", displayInput: "second" };
+    inputQueue.queueFollowUp(submission);
+    inputQueue.queueFollowUp(second);
+    expect(inputQueue.takeNextFollowUp()).toBe(submission);
+    const pending = preflightSubmission(f.options);
+    f.finish("missing key");
+    expect(await pending).toBeFalse();
+    expect(inputQueue.autoSend).toBeFalse();
+    expect(f.states.at(-1)?.queuedInputs).toEqual(["original prompt", "second"]);
+    expect(inputQueue.takeNextFollowUp()).toBe(submission);
+    expect(inputQueue.takeNextFollowUp()).toBe(second);
+    expect(inputQueue.hasFollowUps()).toBeFalse();
+    expect(f.state.draft).toBe("");
+  });
+
+  test("retains both a rejected prompt and a newer draft typed during validation", async () => {
+    const f = fixture();
+    const pending = preflightSubmission(f.options);
+    f.state.draft = "newer draft";
+    f.finish("missing key");
+    expect(await pending).toBeFalse();
+    expect(f.state.draft).toBe("newer draft");
+    expect(f.options.inputQueue.takeNextFollowUp()).toBe(f.options.submission);
+    expect(f.options.inputQueue.autoSend).toBeFalse();
+    expect(f.warnings).toEqual(["missing key"]);
+  });
+
+  test("restores direct input to an empty editor without duplicating it in the queue", async () => {
+    const f = fixture();
+    const pending = preflightSubmission(f.options);
+    f.finish("missing key");
+    expect(await pending).toBeFalse();
+    expect(f.state.draft).toBe("original prompt");
+    expect(f.options.inputQueue.hasFollowUps()).toBeFalse();
+    expect(f.options.inputQueue.autoSend).toBeFalse();
+  });
+
+  test("allows configured access without changing drafts or queue state", async () => {
+    const f = fixture();
+    const pending = preflightSubmission(f.options);
+    f.state.draft = "next prompt";
+    f.finish(undefined);
+    expect(await pending).toBeTrue();
+    expect(f.state.draft).toBe("next prompt");
+    expect(f.options.inputQueue.autoSend).toBeTrue();
+    expect(f.states).toEqual([]);
+    expect(f.warnings).toEqual([]);
+  });
+
+  for (const diagnostic of [undefined, "missing key"]) {
+    test(`does not submit or update a stopped TUI after validation (${diagnostic ?? "allowed"})`, async () => {
+      const f = fixture();
+      const pending = preflightSubmission(f.options);
+      f.state.stopped = true;
+      f.finish(diagnostic);
+      expect(await pending).toBeFalse();
+      expect(f.state.draft).toBe("");
+      expect(f.states).toEqual([]);
+      expect(f.warnings).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Diagnose unambiguously keyless Z.AI/BigModel Coding Plan configurations before fresh headless prompts and ordinary TUI turns.
- Preserve rejected input: restore an empty editor, retain newer drafts, and restore popped follow-ups with their ordering and metadata intact. Pause auto-send on rejection and avoid submission after shutdown.
- Defer custom endpoints, environment/project overrides, dotenv files, and resumed headless sessions to the runtime. Management commands remain available; the check neither prints nor changes credentials.

This is a conservative usability preflight, not a general credential resolver or authorization boundary. The independent official-MCP availability fix is intentionally excluded.

## Verification

- Rebased onto `828f398` (main); reviewed the intervening fullscreen-focus change.
- 50 focused tests passed across prompt preflight, TUI preflight, input queue, launcher routing, and notifications.
- Headless/management integration tests passed against the published 3.11.2-19 runtime (0.16.5).
- `bun run typecheck`, `bun run build`, and `git diff --check` passed.
- Both `bun scripts/smoke-prompt-preflight.ts` and `bun scripts/smoke-prompt-preflight-races.ts` passed. The latter exercises delayed validation, a newer editor draft, rejected queued input, and a later successful retry in an actual PTY.
- Earlier full combined-tree validation on `f0d57aa`: 604 passed, zero failed, including the separate MCP fix. This is not a claim that the full suite has been rerun on this isolated rebased branch.

All model-facing tests use local mocks or blocked input; zero paid model requests. Tested on Linux with Node 26.7.0 and Bun 1.3.12. No generated bundles, private config, audit artifacts, or unrelated fixes are included.
