### PR TITLE
fix(tui): serialize permission dialogs

### DIFF
--- a/packages/zcode-tui/src/index.ts
+++ b/packages/zcode-tui/src/index.ts
@@ -115,6 +115,7 @@ import {
   type UserQuestion
 } from "./interactions.ts";
 import { PermissionPreview } from "./permission-view.ts";
+import { PermissionRequestQueue } from "./permission-request-queue.ts";
 import { createRuntimePluginReferenceLister } from "./plugin-references.ts";
 import {
   formatWorkflowPanel,
@@ -658,6 +659,7 @@ class ZCodeTui {
   private workflowPanel?: Record<string, unknown>;
   private workflowView?: Markdown;
   private workflowRefreshInFlight = false;
+  private readonly permissionRequests = new PermissionRequestQueue();
   private choiceDepth = 0;
   private settingSwitchInFlight = false;
   private fullscreenWelcomeVisible = true;
@@ -3268,12 +3270,18 @@ class ZCodeTui {
     this.ui.requestRender();
   }
 
-  private async requestPermission(requestValue: unknown, context?: unknown): Promise<unknown> {
-    const request = isRecord(requestValue) ? requestValue : {};
+  private requestPermission(requestValue: unknown, context?: unknown): Promise<unknown> {
     const contextRecord = isRecord(context) ? context : undefined;
     const signal = contextRecord?.abortSignal instanceof AbortSignal
       ? contextRecord.abortSignal
       : this.turnAbortController?.signal;
+    return this.permissionRequests.run(
+      () => this.requestPermissionUnqueued(requestValue, signal)
+    );
+  }
+
+  private async requestPermissionUnqueued(requestValue: unknown, signal?: AbortSignal): Promise<unknown> {
+    const request = isRecord(requestValue) ? requestValue : {};
     const toolName = asString(request.toolName) ?? "tool";
     const asksUserQuestion = isAskUserQuestionTool(toolName);
     const toolCallId = asString(request.toolCallId) ?? asString(request.toolUseId) ?? asString(request.callId);
@@ -5145,7 +5153,7 @@ class ZCodeTui {
       return await choose(this.ui, this.choiceHost, this.theme, options);
     } finally {
       this.choiceDepth = Math.max(0, this.choiceDepth - 1);
-      this.focusEditor();
+      if (this.choiceDepth === 0) this.focusEditor();
       this.ui.requestRender();
     }
   }
@@ -5156,7 +5164,7 @@ class ZCodeTui {
       return await promptText(this.ui, this.choiceHost, this.theme, options);
     } finally {
       this.choiceDepth = Math.max(0, this.choiceDepth - 1);
-      this.focusEditor();
+      if (this.choiceDepth === 0) this.focusEditor();
       this.ui.requestRender();
     }
   }

--- a/packages/zcode-tui/src/permission-request-queue.ts
+++ b/packages/zcode-tui/src/permission-request-queue.ts
@@ -1,0 +1,14 @@
+/** Runs complete permission interactions in FIFO order so their dialogs never overlap. */
+export class PermissionRequestQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  run<T>(request: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(request);
+    // A failed request must not poison the queue or block later permissions.
+    this.tail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+}

--- a/test/permission-request-queue.test.ts
+++ b/test/permission-request-queue.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  Container,
+  type Component,
+  type TUI
+} from "@earendil-works/pi-tui";
+
+import { choose, promptText } from "../packages/zcode-tui/src/choice-dialog.ts";
+import { PermissionRequestQueue } from "../packages/zcode-tui/src/permission-request-queue.ts";
+import { createTheme } from "../packages/zcode-tui/src/theme.ts";
+
+function dialogHarness(): {
+  focus: { current: Component | null };
+  host: Container;
+  ui: TUI;
+} {
+  const focus: { current: Component | null } = { current: null };
+  const host = new Container();
+  const ui = {
+    terminal: { columns: 100, rows: 24 },
+    requestRender() {},
+    setFocus(component: Component | null) {
+      focus.current = component;
+    }
+  } as unknown as TUI;
+  return { focus, host, ui };
+}
+
+function permissionDialog(ui: TUI, host: Container, title: string, signal?: AbortSignal) {
+  return choose(ui, host, createTheme(false), {
+    title,
+    prompt: `${title} requests permission to continue.`,
+    items: [{ value: "allow", label: "Allow" }],
+    signal
+  });
+}
+
+describe("permission request queue", () => {
+  test("presents concurrent permission dialogs one at a time", async () => {
+    const queue = new PermissionRequestQueue();
+    const { focus, host, ui } = dialogHarness();
+
+    const first = queue.run(async () => {
+      const decision = await permissionDialog(ui, host, "First tool");
+      const feedback = await promptText(ui, host, createTheme(false), {
+        title: "First tool follow-up",
+        prompt: "Complete the first permission interaction."
+      });
+      return { decision, feedback };
+    });
+    const second = queue.run(() => permissionDialog(ui, host, "Second tool"));
+    await Promise.resolve();
+
+    expect(host.children).toHaveLength(1);
+    expect(host.render(100).join("\n")).toContain("First tool");
+    expect(focus.current).toBe(host.children[0] ?? null);
+
+    host.children[0]?.handleInput?.("\r");
+    await Promise.resolve();
+
+    expect(host.children).toHaveLength(1);
+    expect(host.render(100).join("\n")).toContain("First tool follow-up");
+    expect(host.render(100).join("\n")).not.toContain("Second tool");
+    focus.current?.handleInput?.("Approved after review.");
+    focus.current?.handleInput?.("\r");
+    expect(await first).toEqual({
+      decision: expect.objectContaining({ value: "allow" }),
+      feedback: "Approved after review."
+    });
+    await Promise.resolve();
+
+    expect(host.children).toHaveLength(1);
+    expect(host.render(100).join("\n")).toContain("Second tool");
+    expect(focus.current).toBe(host.children[0] ?? null);
+
+    host.children[0]?.handleInput?.("\x1b");
+    expect(await second).toBeNull();
+    expect(host.children).toHaveLength(0);
+  });
+
+  test("settles active and queued dialogs when their turn is aborted", async () => {
+    const queue = new PermissionRequestQueue();
+    const { host, ui } = dialogHarness();
+    const controller = new AbortController();
+
+    const first = queue.run(() => permissionDialog(ui, host, "First tool", controller.signal));
+    const second = queue.run(() => permissionDialog(ui, host, "Second tool", controller.signal));
+    await Promise.resolve();
+
+    expect(host.children).toHaveLength(1);
+    controller.abort();
+
+    expect(await Promise.all([first, second])).toEqual([null, null]);
+    expect(host.children).toHaveLength(0);
+  });
+
+  test("continues with the next request after an exception", async () => {
+    const queue = new PermissionRequestQueue();
+    const { host, ui } = dialogHarness();
+
+    const failed = queue.run(async () => {
+      throw new Error("permission rendering failed");
+    });
+    const next = queue.run(() => permissionDialog(ui, host, "Next tool"));
+
+    await expect(failed).rejects.toThrow("permission rendering failed");
+    await Promise.resolve();
+
+    expect(host.children).toHaveLength(1);
+    expect(host.render(100).join("\n")).toContain("Next tool");
+    host.children[0]?.handleInput?.("\r");
+    expect(await next).toMatchObject({ value: "allow" });
+  });
+});


### PR DESCRIPTION
## Summary

- serialize complete permission interactions through a per-TUI FIFO queue
- capture each request abort signal before it waits in the queue
- only restore editor focus after all choice or text dialogs have closed
- add regression coverage for concurrent multi-step dialogs, aborts, and exceptions

## Testing

- `bun test test/permission-request-queue.test.ts test/choice-dialog.test.ts`
- `bun run typecheck`
- `bun run build`

Closes #140
