### PR TITLE
test: keep all suites in release validation

### DIFF
--- a/scripts/build-release.ts
+++ b/scripts/build-release.ts
@@ -32,7 +32,7 @@ try {
   await run(["run", "typecheck"]);
   await run(["run", latest ? "sync" : "sync:locked"]);
   latestRuntimeSynced = latest;
-  await run(["test"]);
+  await run(["run", "test:all"]);
   await run(["run", "check"]);
   await run(["run", "check:tui"]);
   await run(["scripts/check-package.ts"]);

--- a/test/release-package.test.ts
+++ b/test/release-package.test.ts
@@ -66,6 +66,10 @@ describe("release package", () => {
     expect(packageJson.scripts.build).toBe("tsdown");
     expect(packageJson.scripts["build:launcher"]).toContain("--filter launcher");
     expect(packageJson.scripts["build:tui"]).toContain("--filter tui");
+    expect(packageJson.scripts.test).toBe("bun run test:fast");
+    expect(packageJson.scripts["test:all"]).toContain("test:fast");
+    expect(packageJson.scripts["test:all"]).toContain("test:tui");
+    expect(packageJson.scripts["test:all"]).toContain("test:runtime");
     expect(packageJson.bin.zcode).toBe("bin/zcode.js");
     expect(packageJson.engines).toEqual({ node: ">=22.19.0" });
     expect(packageJson.dependencies.zigpty).toBeUndefined();
@@ -83,7 +87,7 @@ describe("release package", () => {
   test("syncs the runtime before running runtime-backed integration tests", async () => {
     const source = await Bun.file(new URL("../scripts/build-release.ts", import.meta.url)).text();
     const syncStep = source.indexOf('await run(["run", latest ? "sync" : "sync:locked"]);');
-    const testStep = source.indexOf('await run(["test"]);');
+    const testStep = source.indexOf('await run(["run", "test:all"]);');
 
     expect(syncStep).toBeGreaterThan(-1);
     expect(testStep).toBeGreaterThan(syncStep);


### PR DESCRIPTION
## Summary

- run the new fast, TUI, and runtime groups from `release:build`
- retain fast-only behavior for the normal `bun run test` development command
- assert that release validation cannot silently omit either new suite

## Why

PR #142 split tests into three operational groups and made `test` fast-only. `release:build` still invoked that default, so CI would otherwise skip the TUI scenario and runtime groups.

## Test plan

- `bun test test/release-package.test.ts`
- `bun run typecheck`
- all three suites passed before #142 was merged: 647 fast, 4 TUI, 13 runtime