### PR TITLE
test(tui): assert against visible terminal state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "playwright-core": "1.59.1",
       },
       "devDependencies": {
+        "@xterm/headless": "6.0.0",
         "beautiful-mermaid": "^1.1.3",
         "bun-types": "^1.3.14",
         "cli-highlight": "^2.1.11",
@@ -109,6 +110,8 @@
     "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
 
     "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LDJtpOKtcv9f3V0eDUwFmmy47t2VC+DAuN+gq80R1IA+fa0d408i6sHsVtt6n+g5rf8f86ySoPSAe94lHt6Ixw=="],
 

--- a/docs/TUI_SCENARIO_TESTING.md
+++ b/docs/TUI_SCENARIO_TESTING.md
@@ -53,6 +53,10 @@ Manual mode prints the temporary workspace path before opening the TUI. Enter
 
 - `test/tui/harness/terminal-session.ts` owns the PTY, input, output matching,
   timeouts, and failure diagnostics.
+- `test/tui/harness/terminal-screen.ts` parses PTY bytes into the current
+  visible terminal cells, including cursor movement, erasure, and alternate
+  screen transitions. It uses the pinned experimental `@xterm/headless`
+  buffer API so dependency upgrades must be reviewed explicitly.
 - `test/tui/harness/scenario-workspace.ts` creates an isolated HOME and working
   tree with a separate real Git directory and deterministic configuration.
 - `test/tui/scenarios/` declares user-visible actions and assertions.
@@ -60,8 +64,9 @@ Manual mode prints the temporary workspace path before opening the TUI. Enter
 - `scripts/tui-scenario.ts` exposes automatic and manual execution modes.
 
 A scenario should describe behavior rather than terminal timing. Use
-`waitFor()` or `sendAndWait()` to synchronize on visible state; do not add fixed
-sleeps except for a short render settle.
+`waitForScreen()` or `sendAndWait()` to synchronize on visible state; do not
+add fixed sleeps except for a short render settle. Use `waitForHistory()` only
+for transient output that is intentionally no longer visible.
 
 ## Isolation and Git
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "playwright-core": "1.59.1"
   },
   "devDependencies": {
+    "@xterm/headless": "6.0.0",
     "beautiful-mermaid": "^1.1.3",
     "bun-types": "^1.3.14",
     "cli-highlight": "^2.1.11",

--- a/test/tui/harness/terminal-screen.ts
+++ b/test/tui/harness/terminal-screen.ts
@@ -1,0 +1,87 @@
+import { Terminal as HeadlessTerminal } from "@xterm/headless";
+
+export interface TerminalScreenSnapshot {
+  buffer: "alternate" | "normal";
+  cols: number;
+  cursor: {
+    x: number;
+    y: number;
+  };
+  rows: number;
+  text: string;
+}
+
+function linesText(lines: string[]): string {
+  while (lines.at(-1) === "") lines.pop();
+  return lines.join("\n");
+}
+
+export class TerminalScreen implements Disposable {
+  readonly #terminal: HeadlessTerminal;
+  #pendingWrite: Promise<void> = Promise.resolve();
+
+  constructor(cols: number, rows: number, scrollback = 2_000) {
+    this.#terminal = new HeadlessTerminal({
+      allowProposedApi: true,
+      cols,
+      rows,
+      scrollback
+    });
+  }
+
+  write(data: string | Uint8Array): Promise<void> {
+    const owned = typeof data === "string" ? data : Uint8Array.from(data);
+    this.#pendingWrite = this.#pendingWrite.then(() => new Promise<void>((resolve) => {
+      this.#terminal.write(owned, resolve);
+    }));
+    return this.#pendingWrite;
+  }
+
+  async settled(): Promise<void> {
+    await this.#pendingWrite;
+  }
+
+  screenText(): string {
+    const buffer = this.#terminal.buffer.active;
+    const lines: string[] = [];
+    for (let row = 0; row < this.#terminal.rows; row += 1) {
+      lines.push(buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? "");
+    }
+    return linesText(lines);
+  }
+
+  bufferText(): string {
+    const buffer = this.#terminal.buffer.active;
+    const lines: string[] = [];
+    for (let row = 0; row < buffer.length; row += 1) {
+      lines.push(buffer.getLine(row)?.translateToString(true) ?? "");
+    }
+    return linesText(lines);
+  }
+
+  snapshot(): TerminalScreenSnapshot {
+    const buffer = this.#terminal.buffer.active;
+    return {
+      buffer: buffer.type,
+      cols: this.#terminal.cols,
+      cursor: {
+        x: buffer.cursorX,
+        y: buffer.cursorY
+      },
+      rows: this.#terminal.rows,
+      text: this.screenText()
+    };
+  }
+
+  resize(cols: number, rows: number): void {
+    this.#terminal.resize(cols, rows);
+  }
+
+  dispose(): void {
+    this.#terminal.dispose();
+  }
+
+  [Symbol.dispose](): void {
+    this.dispose();
+  }
+}

--- a/test/tui/harness/terminal-session.ts
+++ b/test/tui/harness/terminal-session.ts
@@ -1,10 +1,11 @@
 import { ScenarioJournal } from "./scenario-journal.ts";
 import type { ScenarioWorkspace } from "./scenario-workspace.ts";
+import { TerminalScreen, type TerminalScreenSnapshot } from "./terminal-screen.ts";
 
 const defaultWaitMilliseconds = 8_000;
 const renderSettleMilliseconds = 30;
 
-export function terminalPlainText(value: string): string {
+function terminalPlainText(value: string): string {
   return value
     .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
     .replace(/\x1bP[^\x07]*(?:\x07|\x1b\\)/g, "")
@@ -26,33 +27,39 @@ export class TerminalSession implements AsyncDisposable {
   readonly #terminal: Bun.Terminal;
   readonly #child: Bun.Subprocess;
   readonly #timeout: ReturnType<typeof setTimeout>;
-  #output = "";
+  readonly #decoder = new TextDecoder();
+  readonly #screen: TerminalScreen;
+  #historyOutput = "";
+  #screenError: unknown;
   #closed = false;
 
   private constructor(
     terminal: Bun.Terminal,
     child: Bun.Subprocess,
     timeout: ReturnType<typeof setTimeout>,
-    journal: ScenarioJournal
+    journal: ScenarioJournal,
+    screen: TerminalScreen
   ) {
     this.#terminal = terminal;
     this.#child = child;
     this.#timeout = timeout;
     this.journal = journal;
+    this.#screen = screen;
   }
 
   static start(options: TerminalSessionOptions): TerminalSession {
-    const decoder = new TextDecoder();
+    const cols = options.cols ?? 110;
+    const rows = options.rows ?? 40;
+    const pendingOutput: Uint8Array[] = [];
     let session: TerminalSession | undefined;
     const terminal = new Bun.Terminal({
-      cols: options.cols ?? 110,
-      rows: options.rows ?? 40,
+      cols,
+      rows,
       name: "xterm-256color",
       data(_terminal, data) {
-        const decoded = decoder.decode(data, { stream: true });
-        if (session) {
-          session.#output += decoded;
-        }
+        const owned = Uint8Array.from(data);
+        if (session) session.consumeOutput(owned);
+        else pendingOutput.push(owned);
       }
     });
     const child = Bun.spawn(options.command, {
@@ -72,17 +79,45 @@ export class TerminalSession implements AsyncDisposable {
       () => child.kill("SIGKILL"),
       options.timeoutMilliseconds ?? 20_000
     );
-    session = new TerminalSession(terminal, child, timeout, options.workspace.journal);
+    session = new TerminalSession(
+      terminal,
+      child,
+      timeout,
+      options.workspace.journal,
+      new TerminalScreen(cols, rows)
+    );
+    for (const data of pendingOutput) session.consumeOutput(data);
     session.journal.record("terminal.start", { command: options.command, pid: child.pid });
     return session;
   }
 
-  checkpoint(): number {
-    return this.#output.length;
+  private consumeOutput(data: Uint8Array): void {
+    this.#historyOutput += this.#decoder.decode(data, { stream: true });
+    void this.#screen.write(data).catch((error) => {
+      this.#screenError ??= error;
+    });
   }
 
-  text(start = 0): string {
-    return terminalPlainText(this.#output.slice(start));
+  historyCheckpoint(): number {
+    return this.#historyOutput.length;
+  }
+
+  historyText(start = 0): string {
+    return terminalPlainText(this.#historyOutput.slice(start));
+  }
+
+  screenText(): string {
+    this.throwScreenError();
+    return this.#screen.screenText();
+  }
+
+  screenSnapshot(): TerminalScreenSnapshot {
+    this.throwScreenError();
+    return this.#screen.snapshot();
+  }
+
+  private throwScreenError(): void {
+    if (this.#screenError) throw new Error("Headless terminal failed to parse PTY output.", { cause: this.#screenError });
   }
 
   send(input: string): void {
@@ -90,11 +125,39 @@ export class TerminalSession implements AsyncDisposable {
     this.#terminal.write(input);
   }
 
-  async settle(): Promise<void> {
-    await Bun.sleep(renderSettleMilliseconds);
+  resize(cols: number, rows: number): void {
+    this.#screen.resize(cols, rows);
+    this.#terminal.resize(cols, rows);
+    this.journal.record("terminal.resize", { cols, rows });
   }
 
-  async waitFor(
+  async settle(): Promise<void> {
+    await Bun.sleep(renderSettleMilliseconds);
+    await this.#screen.settled();
+    this.throwScreenError();
+  }
+
+  async waitForScreen(
+    label: string,
+    pattern: RegExp,
+    timeoutMilliseconds = defaultWaitMilliseconds
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMilliseconds;
+    while (Date.now() < deadline) {
+      await this.#screen.settled();
+      this.throwScreenError();
+      pattern.lastIndex = 0;
+      if (pattern.test(this.screenText())) {
+        this.journal.record("assert.screen.match", { label, pattern: String(pattern) });
+        return;
+      }
+      if (this.#child.exitCode !== null) break;
+      await Bun.sleep(20);
+    }
+    throw this.waitError(label, pattern, "screen");
+  }
+
+  async waitForHistory(
     label: string,
     pattern: RegExp,
     start = 0,
@@ -103,18 +166,25 @@ export class TerminalSession implements AsyncDisposable {
     const deadline = Date.now() + timeoutMilliseconds;
     while (Date.now() < deadline) {
       pattern.lastIndex = 0;
-      if (pattern.test(this.text(start))) {
-        this.journal.record("assert.match", { label, pattern: String(pattern) });
+      if (pattern.test(this.historyText(start))) {
+        this.journal.record("assert.history.match", { label, pattern: String(pattern) });
         return;
       }
       if (this.#child.exitCode !== null) break;
       await Bun.sleep(20);
     }
-    throw new Error([
-      `Timed out waiting for ${label} (${String(pattern)}).`,
+    throw this.waitError(label, pattern, "history");
+  }
+
+  private waitError(label: string, pattern: RegExp, target: "history" | "screen"): Error {
+    return new Error([
+      `Timed out waiting for ${label} in terminal ${target} (${String(pattern)}).`,
       "",
-      "Terminal output:",
-      this.text().slice(-6_000),
+      "Current screen:",
+      this.screenText(),
+      "",
+      "Terminal history:",
+      this.historyText().slice(-6_000),
       "",
       "Scenario journal:",
       this.journal.format()
@@ -126,20 +196,20 @@ export class TerminalSession implements AsyncDisposable {
     label: string,
     pattern: RegExp,
     timeoutMilliseconds?: number
-  ): Promise<number> {
-    const start = this.checkpoint();
+  ): Promise<void> {
     this.send(input);
-    await this.waitFor(label, pattern, start, timeoutMilliseconds);
+    await this.waitForScreen(label, pattern, timeoutMilliseconds);
     await this.settle();
-    return start;
   }
 
-  assertNotVisible(label: string, pattern: RegExp, start = 0): void {
+  async assertScreenExcludes(label: string, pattern: RegExp): Promise<void> {
+    await this.#screen.settled();
+    this.throwScreenError();
     pattern.lastIndex = 0;
-    if (pattern.test(this.text(start))) {
-      throw new Error(`${label} was visible before it should be.\n${this.text(start).slice(-4_000)}`);
+    if (pattern.test(this.screenText())) {
+      throw new Error(`${label} was visible before it should be.\n${this.screenText()}`);
     }
-    this.journal.record("assert.absent", { label, pattern: String(pattern) });
+    this.journal.record("assert.screen.absent", { label, pattern: String(pattern) });
   }
 
   async exit(): Promise<void> {
@@ -163,6 +233,12 @@ export class TerminalSession implements AsyncDisposable {
       await this.#child.exited;
     }
     if (!this.#terminal.closed) this.#terminal.close();
+    try {
+      await this.#screen.settled();
+      this.#historyOutput += this.#decoder.decode();
+    } finally {
+      this.#screen.dispose();
+    }
     this.journal.record("terminal.dispose", { exitCode: this.#child.exitCode });
   }
 

--- a/test/tui/scenarios/permission-request-queue.ts
+++ b/test/tui/scenarios/permission-request-queue.ts
@@ -7,16 +7,15 @@ export const permissionRequestQueueScenario: TuiScenario = {
   description: "Serializes concurrent permission requests, including deny feedback.",
   fixture: join(import.meta.dir, "..", "fixtures", "permission-request-queue.ts"),
   async run(session) {
-    await session.waitFor("scenario instructions", /Type “trigger permissions” to start/i);
-    const turn = session.checkpoint();
+    await session.waitForScreen("scenario instructions", /Type “trigger permissions” to start/i);
     session.send("trigger permissions\r");
-    await session.waitFor("first permission", /FIRST_WRITE_PERMISSION/iu, turn);
+    await session.waitForScreen("first permission", /FIRST_WRITE_PERMISSION/iu);
     await session.sendAndWait(
       "3",
       "first permission feedback prompt",
       /Tell ZCode what should change before retrying\./iu
     );
-    session.assertNotVisible("second permission", /SECOND_BASH_PERMISSION/iu, turn);
+    await session.assertScreenExcludes("second permission", /SECOND_BASH_PERMISSION/iu);
     await session.sendAndWait(
       "Use a temporary output file.\r",
       "second permission",

--- a/test/tui/scenarios/write-and-diff.ts
+++ b/test/tui/scenarios/write-and-diff.ts
@@ -10,7 +10,7 @@ export const writeAndDiffScenario: TuiScenario = {
     "src/example.ts": "export const value = 1;\n"
   },
   async run(session, workspace) {
-    await session.waitFor("scenario instructions", /Type “modify workspace” to start/i);
+    await session.waitForScreen("scenario instructions", /Type “modify workspace” to start/i);
     await session.sendAndWait(
       "modify workspace\r",
       "mock Write completion",
@@ -34,8 +34,8 @@ export const writeAndDiffScenario: TuiScenario = {
       "real Git diff detail",
       /Diff · src\/example\.ts[\s\S]*Page 1\/\d+/iu
     );
-    if (!/export const value = 2;/u.test(session.text())) {
-      throw new Error(`The TUI did not render the updated line.\n${session.text().slice(-4_000)}`);
+    if (!/export const value = 2;/u.test(session.screenText())) {
+      throw new Error(`The TUI did not render the updated line.\n${session.screenText()}`);
     }
     session.send("\x1b");
     await session.settle();

--- a/test/tui/terminal-screen.test.ts
+++ b/test/tui/terminal-screen.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+
+import { TerminalScreen } from "./harness/terminal-screen.ts";
+
+test("headless terminal reports the current screen instead of erased output", async () => {
+  using screen = new TerminalScreen(20, 4);
+  await screen.write("stale panel");
+  expect(screen.screenText()).toContain("stale panel");
+
+  await screen.write("\x1b[2J\x1b[Hcurrent panel");
+
+  expect(screen.screenText()).toBe("current panel");
+  expect(screen.bufferText()).not.toContain("stale panel");
+});
+
+test("headless terminal follows alternate-screen transitions", async () => {
+  using screen = new TerminalScreen(20, 4);
+  await screen.write("main screen");
+  await screen.write("\x1b[?1049h\x1b[Halternate");
+
+  expect(screen.snapshot()).toMatchObject({
+    buffer: "alternate",
+    cols: 20,
+    rows: 4,
+    text: "alternate"
+  });
+
+  await screen.write("\x1b[?1049l");
+
+  expect(screen.snapshot()).toMatchObject({
+    buffer: "normal",
+    text: "main screen"
+  });
+});
+
+test("headless terminal separates the visible viewport from scrollback", async () => {
+  using screen = new TerminalScreen(20, 3);
+  await screen.write("one\r\ntwo\r\nthree\r\nfour");
+
+  expect(screen.screenText()).toBe("two\nthree\nfour");
+  expect(screen.bufferText()).toBe("one\ntwo\nthree\nfour");
+});
+
+test("headless terminal preserves visible Unicode cells and resize state", async () => {
+  using screen = new TerminalScreen(12, 3);
+  await screen.write("权限 ✓");
+  screen.resize(16, 4);
+
+  expect(screen.snapshot()).toEqual({
+    buffer: "normal",
+    cols: 16,
+    cursor: { x: 6, y: 0 },
+    rows: 4,
+    text: "权限 ✓"
+  });
+});


### PR DESCRIPTION
## Summary

- parse PTY output with a pinned `@xterm/headless` terminal model
- expose current-screen, scrollback history, snapshots, and synchronized resize operations from the TUI scenario harness
- make scenario waits and negative assertions target currently visible cells instead of stale ANSI output
- migrate permission queue and Write `/diff` scenarios to screen-based assertions
- cover erasure, alternate screen transitions, scrollback, Unicode width, and resize behavior

## Why

Raw PTY history can retain text after the TUI clears or overwrites it. Tests that search that history may pass even when the expected panel is no longer visible. This change makes automated assertions reflect what a person actually sees in the terminal.

## Test plan

- `bun install --frozen-lockfile`
- `TMPDIR=/tmp bun run test:all`
  - fast: 647 passed
  - TUI: 8 passed
  - runtime: 13 passed
- `bun run typecheck`
- `bun run build`