### PR TITLE
test(tui): add typed scenario runtime

### DIFF
--- a/docs/TUI_SCENARIO_TESTING.md
+++ b/docs/TUI_SCENARIO_TESTING.md
@@ -61,12 +61,22 @@ Manual mode prints the temporary workspace path before opening the TUI. Enter
   tree with a separate real Git directory and deterministic configuration.
 - `test/tui/scenarios/` declares user-visible actions and assertions.
 - `test/tui/fixtures/` provides typed `RuntimeAdapter` behavior to the real TUI.
+- `test/tui/runtime/scenario-runtime.ts` maps declared prompt routes to typed
+  event, delay, permission, file-write, and response steps.
 - `scripts/tui-scenario.ts` exposes automatic and manual execution modes.
 
 A scenario should describe behavior rather than terminal timing. Use
 `waitForScreen()` or `sendAndWait()` to synchronize on visible state; do not
 add fixed sleeps except for a short render settle. Use `waitForHistory()` only
 for transient output that is intentionally no longer visible.
+
+Runtime fixtures should use `createScenarioRuntime()` rather than implementing
+`submitPrompt()` directly. Every turn must have a unique id and end in one
+`respond` step. Unknown input fails unless the fixture declares an
+`unmatchedResponse`. Permission batches explicitly choose parallel or
+sequential execution, delays observe the turn abort signal, and writes cannot
+escape the scenario workspace. Runtime steps are also written to
+`runtime.jsonl`; automatic failures include that journal in their diagnostics.
 
 ## Isolation and Git
 

--- a/test/tui/fixtures/permission-request-queue.ts
+++ b/test/tui/fixtures/permission-request-queue.ts
@@ -1,13 +1,44 @@
 #!/usr/bin/env bun
 
 import { runTui } from "../../../packages/zcode-tui/src/index.ts";
-import type { PromptCallOptions } from "../../../packages/zcode-tui/src/types.ts";
+import { createScenarioRuntime } from "../runtime/scenario-runtime.ts";
 
 function decisionSummary(value: unknown): string {
   if (typeof value !== "object" || value === null) return "unknown";
   const record = value as Record<string, unknown>;
   return `${String(record.decision ?? "unknown")} · ${String(record.reason ?? "no reason")}`;
 }
+
+const runtime = createScenarioRuntime({
+  journalPath: process.env.ZCODE_TUI_SCENARIO_RUNTIME_JOURNAL,
+  unmatchedResponse: "Type “trigger permissions” to start.",
+  turns: [{
+    id: "concurrent-permissions",
+    match: "trigger permissions",
+    steps: [{
+      type: "permissions",
+      mode: "parallel",
+      saveAs: "permissions",
+      requests: [{
+        toolCallId: "scenario_write",
+        toolName: "Write",
+        reason: "FIRST_WRITE_PERMISSION",
+        input: { file_path: "output.txt", content: "first" }
+      }, {
+        toolCallId: "scenario_bash",
+        toolName: "Bash",
+        reason: "SECOND_BASH_PERMISSION",
+        input: { command: "printf second" }
+      }]
+    }, {
+      type: "respond",
+      response: (context) => {
+        const [firstDecision, secondDecision] = context.value<unknown[]>("permissions");
+        return `Permission queue complete: ${decisionSummary(firstDecision)} | ${decisionSummary(secondDecision)}`;
+      }
+    }]
+  }]
+});
 
 await runTui({
   version: "permission-queue-scenario",
@@ -22,28 +53,7 @@ await runTui({
       content: "Type “trigger permissions” to start the concurrent permission scenario."
     }
   ],
-  submitPrompt: async (input: unknown, options: PromptCallOptions) => {
-    if (String(input) !== "trigger permissions") {
-      return { response: "Type “trigger permissions” to start." };
-    }
-    if (!options.requestPermission) throw new Error("Permission callback is unavailable.");
-    const first = options.requestPermission({
-      toolCallId: "scenario_write",
-      toolName: "Write",
-      reason: "FIRST_WRITE_PERMISSION",
-      input: { file_path: "output.txt", content: "first" }
-    }, { abortSignal: options.abortSignal });
-    const second = options.requestPermission({
-      toolCallId: "scenario_bash",
-      toolName: "Bash",
-      reason: "SECOND_BASH_PERMISSION",
-      input: { command: "printf second" }
-    }, { abortSignal: options.abortSignal });
-    const [firstDecision, secondDecision] = await Promise.all([first, second]);
-    return {
-      response: `Permission queue complete: ${decisionSummary(firstDecision)} | ${decisionSummary(secondDecision)}`
-    };
-  },
+  submitPrompt: runtime.submitPrompt,
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr

--- a/test/tui/fixtures/write-and-diff.ts
+++ b/test/tui/fixtures/write-and-diff.ts
@@ -1,9 +1,27 @@
 #!/usr/bin/env bun
 
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-
 import { runTui } from "../../../packages/zcode-tui/src/index.ts";
+import { createScenarioRuntime } from "../runtime/scenario-runtime.ts";
+
+const runtime = createScenarioRuntime({
+  journalPath: process.env.ZCODE_TUI_SCENARIO_RUNTIME_JOURNAL,
+  unmatchedResponse: "Type “modify workspace” to start.",
+  workspaceDirectory: process.cwd(),
+  turns: [{
+    id: "modify-workspace",
+    match: "modify workspace",
+    steps: [{
+      type: "writeFiles",
+      files: {
+        "src/example.ts": "export const value = 2;\n",
+        "src/created.ts": "export const created = true;\n"
+      }
+    }, {
+      type: "respond",
+      response: "Workspace write complete."
+    }]
+  }]
+});
 
 await runTui({
   version: "write-and-diff-scenario",
@@ -18,17 +36,7 @@ await runTui({
       content: "Type “modify workspace” to start the isolated Write and real Git diff scenario."
     }
   ],
-  submitPrompt: async (input: unknown) => {
-    if (String(input) !== "modify workspace") {
-      return { response: "Type “modify workspace” to start." };
-    }
-    await mkdir(join(process.cwd(), "src"), { recursive: true });
-    await Promise.all([
-      writeFile(join(process.cwd(), "src", "example.ts"), "export const value = 2;\n"),
-      writeFile(join(process.cwd(), "src", "created.ts"), "export const created = true;\n")
-    ]);
-    return { response: "Workspace write complete." };
-  },
+  submitPrompt: runtime.submitPrompt,
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr

--- a/test/tui/harness/run-scenario.ts
+++ b/test/tui/harness/run-scenario.ts
@@ -11,7 +11,14 @@ export async function runAutomatedTuiScenario(scenario: TuiScenario): Promise<vo
     command: [process.execPath, scenario.fixture],
     workspace
   });
-  await scenario.run(session, workspace);
+  try {
+    await scenario.run(session, workspace);
+  } catch (error) {
+    const runtimeJournal = await workspace.readRuntimeJournal();
+    if (!runtimeJournal) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}\n\nRuntime journal:\n${runtimeJournal.trimEnd()}`, { cause: error });
+  }
   await session.exit();
 }
 

--- a/test/tui/harness/scenario-workspace.ts
+++ b/test/tui/harness/scenario-workspace.ts
@@ -24,6 +24,7 @@ export class ScenarioWorkspace implements AsyncDisposable {
   readonly gitDirectory: string;
   readonly home: string;
   readonly journal: ScenarioJournal;
+  readonly runtimeJournalPath: string;
 
   private constructor(root: string, journal: ScenarioJournal) {
     this.root = root;
@@ -31,6 +32,7 @@ export class ScenarioWorkspace implements AsyncDisposable {
     this.gitDirectory = join(root, "git");
     this.home = join(root, "home");
     this.journal = journal;
+    this.runtimeJournalPath = join(root, "runtime.jsonl");
   }
 
   static async create(options: ScenarioWorkspaceOptions = {}): Promise<ScenarioWorkspace> {
@@ -74,7 +76,8 @@ export class ScenarioWorkspace implements AsyncDisposable {
       GIT_CONFIG_NOSYSTEM: "1",
       GIT_PAGER: "cat",
       GIT_TERMINAL_PROMPT: "0",
-      GIT_OPTIONAL_LOCKS: "0"
+      GIT_OPTIONAL_LOCKS: "0",
+      ZCODE_TUI_SCENARIO_RUNTIME_JOURNAL: this.runtimeJournalPath
     };
   }
 
@@ -90,6 +93,10 @@ export class ScenarioWorkspace implements AsyncDisposable {
 
   async read(path: string): Promise<string> {
     return await readFile(this.resolvePath(path), "utf8");
+  }
+
+  async readRuntimeJournal(): Promise<string> {
+    return await readFile(this.runtimeJournalPath, "utf8").catch(() => "");
   }
 
   async git(args: string[], cwd = this.directory): Promise<GitCommandResult> {

--- a/test/tui/runtime/scenario-runtime.ts
+++ b/test/tui/runtime/scenario-runtime.ts
@@ -1,0 +1,262 @@
+import { appendFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+
+import type { PromptCallOptions, RuntimeAdapter } from "../../../packages/zcode-tui/src/types.ts";
+
+export type ScenarioValue<T> = T | ((context: ScenarioTurnContext) => T | Promise<T>);
+export type ScenarioInputMatcher = string | RegExp | ((input: unknown) => boolean);
+
+export interface ScenarioTurnContext {
+  readonly input: unknown;
+  readonly options: PromptCallOptions;
+  value<T>(key: string): T;
+}
+
+export interface ScenarioEmitStep {
+  type: "emit";
+  event: ScenarioValue<unknown>;
+}
+
+export interface ScenarioDelayStep {
+  type: "delay";
+  milliseconds: number;
+}
+
+export interface ScenarioPermissionStep {
+  type: "permissions";
+  mode?: "parallel" | "sequential";
+  requests: ScenarioValue<readonly unknown[]>;
+  saveAs: string;
+}
+
+export interface ScenarioWriteFilesStep {
+  type: "writeFiles";
+  files: ScenarioValue<Readonly<Record<string, string | Uint8Array>>>;
+}
+
+export interface ScenarioRespondStep {
+  type: "respond";
+  response: ScenarioValue<string>;
+  metadata?: ScenarioValue<Record<string, unknown>>;
+}
+
+export type ScenarioRuntimeStep =
+  | ScenarioDelayStep
+  | ScenarioEmitStep
+  | ScenarioPermissionStep
+  | ScenarioRespondStep
+  | ScenarioWriteFilesStep;
+
+export interface ScenarioTurn {
+  id: string;
+  match: ScenarioInputMatcher;
+  steps: readonly ScenarioRuntimeStep[];
+}
+
+export interface ScenarioRuntimeDefinition {
+  turns: readonly ScenarioTurn[];
+  workspaceDirectory?: string;
+  journalPath?: string;
+  unmatchedResponse?: ScenarioValue<string>;
+}
+
+export interface ScenarioRuntimeJournalEntry {
+  sequence: number;
+  kind: string;
+  detail: unknown;
+}
+
+export class ScenarioRuntimeJournal {
+  readonly #entries: ScenarioRuntimeJournalEntry[] = [];
+  readonly #path?: string;
+
+  constructor(path?: string) {
+    this.#path = path;
+  }
+
+  record(kind: string, detail: unknown): void {
+    const entry = {
+      sequence: this.#entries.length + 1,
+      kind,
+      detail
+    };
+    this.#entries.push(entry);
+    if (this.#path) appendFileSync(this.#path, `${JSON.stringify(entry)}\n`);
+  }
+
+  entries(): readonly ScenarioRuntimeJournalEntry[] {
+    return this.#entries;
+  }
+}
+
+export interface ScenarioRuntimeAdapter extends Pick<RuntimeAdapter, "submitPrompt"> {
+  journal: ScenarioRuntimeJournal;
+}
+
+async function scenarioValue<T>(value: ScenarioValue<T>, context: ScenarioTurnContext): Promise<T> {
+  if (typeof value !== "function") return value;
+  return await (value as (context: ScenarioTurnContext) => T | Promise<T>)(context);
+}
+
+function inputMatches(matcher: ScenarioInputMatcher, input: unknown): boolean {
+  if (typeof matcher === "string") return input === matcher;
+  if (matcher instanceof RegExp) {
+    matcher.lastIndex = 0;
+    return matcher.test(String(input));
+  }
+  return matcher(input);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason ?? new DOMException("Scenario turn aborted", "AbortError");
+}
+
+async function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  if (milliseconds === 0) return;
+  await new Promise<void>((resolveDelay, reject) => {
+    const timer = setTimeout(finish, milliseconds);
+    const abort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
+      reject(signal?.reason ?? new DOMException("Scenario turn aborted", "AbortError"));
+    };
+    function finish() {
+      signal?.removeEventListener("abort", abort);
+      resolveDelay();
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function workspacePath(workspaceDirectory: string, path: string): string {
+  const root = resolve(workspaceDirectory);
+  const destination = resolve(root, path);
+  if (destination !== root && !destination.startsWith(`${root}${sep}`)) {
+    throw new Error(`Scenario write escapes the workspace: ${path}`);
+  }
+  return destination;
+}
+
+function validateDefinition(definition: ScenarioRuntimeDefinition): void {
+  const ids = new Set<string>();
+  for (const turn of definition.turns) {
+    if (!turn.id || ids.has(turn.id)) throw new Error(`Scenario turn id must be unique: ${turn.id || "(empty)"}`);
+    ids.add(turn.id);
+    const responses = turn.steps.flatMap((step, index) => step.type === "respond" ? [index] : []);
+    if (responses.length !== 1 || responses[0] !== turn.steps.length - 1) {
+      throw new Error(`Scenario turn "${turn.id}" must end with exactly one respond step.`);
+    }
+    for (const step of turn.steps) {
+      if (step.type === "delay" && (!Number.isFinite(step.milliseconds) || step.milliseconds < 0)) {
+        throw new Error(`Scenario turn "${turn.id}" has an invalid delay.`);
+      }
+      if (step.type === "permissions" && !step.saveAs) {
+        throw new Error(`Scenario turn "${turn.id}" must name its permission result.`);
+      }
+    }
+  }
+}
+
+export function createScenarioRuntime(definition: ScenarioRuntimeDefinition): ScenarioRuntimeAdapter {
+  validateDefinition(definition);
+  const journal = new ScenarioRuntimeJournal(definition.journalPath);
+
+  const submitPrompt = async (input: unknown, options: PromptCallOptions): Promise<unknown> => {
+    throwIfAborted(options.abortSignal);
+    const turn = definition.turns.find((candidate) => inputMatches(candidate.match, input));
+    if (!turn) {
+      if (definition.unmatchedResponse !== undefined) {
+        const values = new Map<string, unknown>();
+        const context = turnContext(input, options, values);
+        const response = await scenarioValue(definition.unmatchedResponse, context);
+        journal.record("turn.unmatched", { input, response });
+        return { response };
+      }
+      journal.record("turn.unmatched", { input });
+      throw new Error(`No scenario turn matches input: ${String(input)}`);
+    }
+
+    const values = new Map<string, unknown>();
+    const context = turnContext(input, options, values);
+    journal.record("turn.start", { input, turnId: turn.id });
+    try {
+      for (const [index, step] of turn.steps.entries()) {
+        throwIfAborted(options.abortSignal);
+        journal.record("step.start", { index, turnId: turn.id, type: step.type });
+        if (step.type === "delay") {
+          await delay(step.milliseconds, options.abortSignal);
+        } else if (step.type === "emit") {
+          const event = await scenarioValue(step.event, context);
+          await options.onEvent?.(event);
+          journal.record("event.emit", { event, turnId: turn.id });
+        } else if (step.type === "permissions") {
+          if (!options.requestPermission) throw new Error("Scenario permission callback is unavailable.");
+          const requests = await scenarioValue(step.requests, context);
+          const invoke = (request: unknown) => options.requestPermission!(
+            request,
+            { abortSignal: options.abortSignal }
+          );
+          const results: unknown[] = [];
+          if ((step.mode ?? "sequential") === "parallel") {
+            results.push(...await Promise.all(requests.map(invoke)));
+          } else {
+            for (const request of requests) results.push(await invoke(request));
+          }
+          values.set(step.saveAs, results);
+          journal.record("permissions.finish", {
+            count: requests.length,
+            mode: step.mode ?? "sequential",
+            results,
+            saveAs: step.saveAs,
+            turnId: turn.id
+          });
+        } else if (step.type === "writeFiles") {
+          if (!definition.workspaceDirectory) {
+            throw new Error(`Scenario turn "${turn.id}" writes files without a workspaceDirectory.`);
+          }
+          const files = await scenarioValue(step.files, context);
+          await Promise.all(Object.entries(files).map(async ([path, contents]) => {
+            const destination = workspacePath(definition.workspaceDirectory!, path);
+            await mkdir(dirname(destination), { recursive: true });
+            await writeFile(destination, contents);
+          }));
+          journal.record("files.write", { paths: Object.keys(files), turnId: turn.id });
+        } else {
+          const response = await scenarioValue(step.response, context);
+          const metadata = step.metadata ? await scenarioValue(step.metadata, context) : {};
+          const result = { ...metadata, response };
+          journal.record("turn.finish", { result, turnId: turn.id });
+          return result;
+        }
+        journal.record("step.finish", { index, turnId: turn.id, type: step.type });
+      }
+      throw new Error(`Scenario turn "${turn.id}" ended without a response.`);
+    } catch (error) {
+      journal.record("turn.error", {
+        error: error instanceof Error ? error.message : String(error),
+        turnId: turn.id
+      });
+      throw error;
+    }
+  };
+
+  return { journal, submitPrompt };
+}
+
+function turnContext(
+  input: unknown,
+  options: PromptCallOptions,
+  values: Map<string, unknown>
+): ScenarioTurnContext {
+  return {
+    input,
+    options,
+    value<T>(key: string): T {
+      if (!values.has(key)) throw new Error(`Scenario value is unavailable: ${key}`);
+      return values.get(key) as T;
+    }
+  };
+}

--- a/test/tui/scenario-runtime.test.ts
+++ b/test/tui/scenario-runtime.test.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "bun:test";
+
+import { ScenarioWorkspace } from "./harness/scenario-workspace.ts";
+import { createScenarioRuntime } from "./runtime/scenario-runtime.ts";
+
+test("scenario runtime matches input, writes isolated files, and journals the response", async () => {
+  await using workspace = await ScenarioWorkspace.create();
+  const runtime = createScenarioRuntime({
+    journalPath: workspace.runtimeJournalPath,
+    workspaceDirectory: workspace.directory,
+    turns: [{
+      id: "write",
+      match: /^write fixture$/u,
+      steps: [{
+        type: "writeFiles",
+        files: { "nested/result.txt": "fixture result\n" }
+      }, {
+        type: "respond",
+        response: "Write complete.",
+        metadata: { sessionId: "scenario-session" }
+      }]
+    }]
+  });
+
+  await expect(runtime.submitPrompt("write fixture", {})).resolves.toEqual({
+    response: "Write complete.",
+    sessionId: "scenario-session"
+  });
+  expect(await workspace.read("nested/result.txt")).toBe("fixture result\n");
+  expect(runtime.journal.entries().map((entry) => entry.kind)).toEqual([
+    "turn.start",
+    "step.start",
+    "files.write",
+    "step.finish",
+    "step.start",
+    "turn.finish"
+  ]);
+  expect(await workspace.readRuntimeJournal()).toContain('"kind":"turn.finish"');
+});
+
+test("scenario runtime starts parallel permission requests before awaiting either result", async () => {
+  const first = Promise.withResolvers<unknown>();
+  const second = Promise.withResolvers<unknown>();
+  const calls: unknown[] = [];
+  const runtime = createScenarioRuntime({
+    turns: [{
+      id: "permissions",
+      match: "run",
+      steps: [{
+        type: "permissions",
+        mode: "parallel",
+        requests: [{ id: "first" }, { id: "second" }],
+        saveAs: "decisions"
+      }, {
+        type: "respond",
+        response: (context) => context.value<string[]>("decisions").join(",")
+      }]
+    }]
+  });
+
+  const submission = runtime.submitPrompt("run", {
+    requestPermission: async (request) => {
+      calls.push(request);
+      return calls.length === 1 ? await first.promise : await second.promise;
+    }
+  });
+  await Bun.sleep(0);
+  expect(calls).toEqual([{ id: "first" }, { id: "second" }]);
+  second.resolve("allow-second");
+  first.resolve("deny-first");
+  await expect(submission).resolves.toEqual({ response: "deny-first,allow-second" });
+});
+
+test("scenario runtime keeps sequential permission requests ordered", async () => {
+  const first = Promise.withResolvers<unknown>();
+  const calls: unknown[] = [];
+  const runtime = createScenarioRuntime({
+    turns: [{
+      id: "permissions",
+      match: "run",
+      steps: [{
+        type: "permissions",
+        requests: [{ id: "first" }, { id: "second" }],
+        saveAs: "decisions"
+      }, {
+        type: "respond",
+        response: "finished"
+      }]
+    }]
+  });
+
+  const submission = runtime.submitPrompt("run", {
+    requestPermission: async (request) => {
+      calls.push(request);
+      if (calls.length === 1) return await first.promise;
+      return "second";
+    }
+  });
+  await Bun.sleep(0);
+  expect(calls).toEqual([{ id: "first" }]);
+  first.resolve("first");
+  await expect(submission).resolves.toEqual({ response: "finished" });
+  expect(calls).toEqual([{ id: "first" }, { id: "second" }]);
+});
+
+test("scenario runtime emits events and cancels abort-aware delays", async () => {
+  const events: unknown[] = [];
+  const runtime = createScenarioRuntime({
+    turns: [{
+      id: "events",
+      match: "events",
+      steps: [{
+        type: "emit",
+        event: { type: "fixture.event", payload: { value: 1 } }
+      }, {
+        type: "respond",
+        response: "events complete"
+      }]
+    }, {
+      id: "delay",
+      match: "delay",
+      steps: [{
+        type: "delay",
+        milliseconds: 5_000
+      }, {
+        type: "respond",
+        response: "too late"
+      }]
+    }]
+  });
+
+  await runtime.submitPrompt("events", {
+    onEvent: (event) => {
+      events.push(event);
+    }
+  });
+  expect(events).toEqual([{ type: "fixture.event", payload: { value: 1 } }]);
+
+  const controller = new AbortController();
+  const delayed = runtime.submitPrompt("delay", { abortSignal: controller.signal });
+  controller.abort(new Error("fixture stopped"));
+  await expect(delayed).rejects.toThrow("fixture stopped");
+  expect(runtime.journal.entries().at(-1)).toMatchObject({
+    kind: "turn.error",
+    detail: { error: "fixture stopped", turnId: "delay" }
+  });
+});
+
+test("scenario runtime rejects unmatched input, unsafe writes, and invalid definitions", async () => {
+  const unmatched = createScenarioRuntime({
+    turns: [{
+      id: "known",
+      match: "known",
+      steps: [{ type: "respond", response: "known" }]
+    }]
+  });
+  await expect(unmatched.submitPrompt("unknown", {})).rejects.toThrow("No scenario turn matches input");
+
+  const unsafe = createScenarioRuntime({
+    workspaceDirectory: process.cwd(),
+    turns: [{
+      id: "unsafe",
+      match: "unsafe",
+      steps: [{
+        type: "writeFiles",
+        files: { "../escaped.txt": "not allowed" }
+      }, {
+        type: "respond",
+        response: "unreachable"
+      }]
+    }]
+  });
+  await expect(unsafe.submitPrompt("unsafe", {})).rejects.toThrow("escapes the workspace");
+
+  expect(() => createScenarioRuntime({
+    turns: [{
+      id: "invalid",
+      match: "invalid",
+      steps: [{ type: "delay", milliseconds: 1 }]
+    }]
+  })).toThrow('must end with exactly one respond step');
+});


### PR DESCRIPTION
## Summary

- add a typed scenario runtime DSL for prompt matching, events, abort-aware delays, permissions, workspace writes, and responses
- migrate the permission queue and write/diff fixtures to declarative runtime scenarios
- persist runtime execution as JSONL and include it in automated failure diagnostics
- document fixture conventions and add focused runtime tests

## Test plan

- `bun run typecheck`
- `bun test test/tui/scenario-runtime.test.ts`
- `bun run test:tui`
- `TMPDIR=/tmp bun run test:all`
- `bun run build`
- `git diff --check`