### PR TITLE
test(tui): add strict HTTP mock backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "bun-types": "^1.3.14",
         "cli-highlight": "^2.1.11",
         "diff": "^9.0.0",
+        "msw": "^2.15.0",
         "tsdown": "^0.22.7",
         "typescript": "^7.0.2",
         "yaml": "^2.8.1",
@@ -29,7 +30,25 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.8", "", {}, "sha512-WpQM+Ti6Z40EFwwt+uL2p4UabT+W179zHp6HhLVOzfbwnVn05IPO/eXIZXGNqcT1jbQ15SujNLzQ39k4QPPxBQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.3.2", "", { "dependencies": { "@inquirer/core": "^12.0.3", "@inquirer/type": "4.1.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Xvr/0HggjddPtGppuqVmxhTw+Hr8PvsZ/k0HmOEaAqQEt80OITNkFWnsdNmyT0/eM4Ab+iJLx2R8rctlEyfSVg=="],
+
+    "@inquirer/core": ["@inquirer/core@12.0.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.8", "@inquirer/figures": "^2.0.9", "@inquirer/type": "4.1.1", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wsSy0sznmXwkty+2PzZwx00Cazc/E0r0B7mAzdGROz2Ct+DFZXaK7WDjGZvgjRldxH5ZhFVfF2lgkYrqgOw2KA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.9", "", {}, "sha512-EAWgUTGQ/Umgga51dE3B2PUHbufuXarDfg86uVgoSgNHNNQnyFKcOrQLWVqYMghuSyHh8+2HUH0Js9cTC1WAdg=="],
+
+    "@inquirer/type": ["@inquirer/type@4.1.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A=="],
+
+    "@mswjs/interceptors": ["@mswjs/interceptors@0.41.9", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
+
+    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
+
+    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
@@ -70,6 +89,10 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
+
+    "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -177,11 +200,15 @@
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -199,6 +226,12 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
@@ -207,7 +240,11 @@
 
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.5", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ=="],
 
+    "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -217,7 +254,13 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
+
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "msw": ["msw@2.15.0", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.11", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
@@ -225,9 +268,15 @@
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
+    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
     "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
@@ -239,17 +288,29 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "rettime": ["rettime@0.11.11", "", {}, "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ=="],
+
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.9", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3", "yuku-ast": "^0.1.7", "yuku-codegen": "^0.6.1", "yuku-parser": "^0.6.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": "*", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-d54yt65+ZF/Mk8H6P36As02PAMdaiWRSzVNtJRc1h7nCgUFjuRI4cN2DyTfJyfVpPH6pgy7/2D7YQH1/Rh75Yg=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -259,17 +320,27 @@
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "tldts": ["tldts@7.4.12", "", { "dependencies": { "tldts-core": "^7.4.12" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA=="],
+
+    "tldts-core": ["tldts-core@7.4.12", "", {}, "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "tsdown": ["tsdown@0.22.7", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.5", "rolldown": "~1.1.5", "rolldown-plugin-dts": "^0.27.8", "semver": "^7.8.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.7", "@tsdown/exe": "0.22.7", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-4egbOzc9dxVv/QS+gDV75FIxDIjQQeOnXBlUuikyjmn0ozuc6FW11djJjEEo3vqkuJRygpnKHurnj+Iwftk4VA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "type-fest": ["type-fest@5.9.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw=="],
+
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -287,6 +358,14 @@
 
     "yuku-parser": ["yuku-parser@0.6.1", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.6.1", "@yuku-parser/binding-darwin-x64": "0.6.1", "@yuku-parser/binding-freebsd-x64": "0.6.1", "@yuku-parser/binding-linux-arm-gnu": "0.6.1", "@yuku-parser/binding-linux-arm-musl": "0.6.1", "@yuku-parser/binding-linux-arm64-gnu": "0.6.1", "@yuku-parser/binding-linux-arm64-musl": "0.6.1", "@yuku-parser/binding-linux-x64-gnu": "0.6.1", "@yuku-parser/binding-linux-x64-musl": "0.6.1", "@yuku-parser/binding-win32-arm64": "0.6.1", "@yuku-parser/binding-win32-x64": "0.6.1" } }, "sha512-dPE3/+H2VBw9LhjoIVeW/axKidYGd+XzNtrwGGseZ0325cQFl0Dpwyh0R74XWe/WqQn4M8CR5YApsv2KF2zN1A=="],
 
+    "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "msw/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
   }
 }

--- a/docs/TUI_SCENARIO_TESTING.md
+++ b/docs/TUI_SCENARIO_TESTING.md
@@ -63,6 +63,8 @@ Manual mode prints the temporary workspace path before opening the TUI. Enter
 - `test/tui/fixtures/` provides typed `RuntimeAdapter` behavior to the real TUI.
 - `test/tui/runtime/scenario-runtime.ts` maps declared prompt routes to typed
   event, delay, permission, file-write, and response steps.
+- `test/tui/runtime/scenario-http.ts` maps declared MSW routes to real fixture
+  `fetch` calls, request assertions, responses, and exact call counts.
 - `scripts/tui-scenario.ts` exposes automatic and manual execution modes.
 
 A scenario should describe behavior rather than terminal timing. Use
@@ -110,12 +112,23 @@ The first backend is intentionally the portable temporary-directory workspace:
 it exercises the actual filesystem and Git without requiring FUSE/NFS setup.
 It is test isolation, not a security boundary.
 
-Future backends should preserve the same scenario contract:
+Network scenarios use `createScenarioHttpMock()` inside the child fixture.
+Routes declare a unique id, HTTP method, URL, response, and optional exact call
+count and request assertion. Responses support JSON, text, empty bodies,
+latency, and network errors. Unhandled requests and failed assertions are
+recorded and cause `assertSatisfied()` to fail. Use one shared
+`ScenarioRuntimeJournal` for the runtime and HTTP mock so diagnostics preserve
+execution order. This intercepts the fixture's real `fetch`; an MSW server in
+the parent test process cannot intercept child-process requests.
+
+Call `httpMock.start()` before `runTui()`, call `httpMock.assertSatisfied()`
+after it exits, and use `using` or `close()` to restore the process network
+state. Do not allow unhandled requests to reach the public network.
+
+Additional backends should preserve the same scenario contract:
 
 - Mountx may provide an optional in-memory mounted workspace for filesystem
   journaling and fault injection. It must not be treated as a sandbox.
-- MSW should be initialized inside each fixture process with unhandled requests
-  configured as errors. Parent-process interception cannot mock child fetches.
 - just-bash may execute allowlisted shell behavior against the scenario
   workspace. It should not expose unrestricted host commands or native Git.
 - Scenarios requiring arbitrary binaries, Git hooks, or untrusted code belong

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "bun-types": "^1.3.14",
     "cli-highlight": "^2.1.11",
     "diff": "^9.0.0",
+    "msw": "^2.15.0",
     "tsdown": "^0.22.7",
     "typescript": "^7.0.2",
     "yaml": "^2.8.1"

--- a/test/tui/fixtures/http-mock.ts
+++ b/test/tui/fixtures/http-mock.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+
+import { runTui } from "../../../packages/zcode-tui/src/index.ts";
+import { createScenarioHttpMock } from "../runtime/scenario-http.ts";
+import {
+  createScenarioRuntime,
+  ScenarioRuntimeJournal
+} from "../runtime/scenario-runtime.ts";
+
+const journal = new ScenarioRuntimeJournal(
+  process.env.ZCODE_TUI_SCENARIO_RUNTIME_JOURNAL
+);
+using httpMock = createScenarioHttpMock({
+  journal,
+  routes: [{
+    id: "model-catalog",
+    method: "GET",
+    url: "https://scenario.invalid/api/models",
+    expectedCalls: 1,
+    assert(context) {
+      if (context.request.headers.get("x-scenario-client") !== "zcode-tui") {
+        throw new Error("The model catalog request is missing its scenario client header.");
+      }
+    },
+    response: {
+      type: "json",
+      body: {
+        models: [
+          { id: "glm-5", name: "GLM-5 Mock" },
+          { id: "glm-4.7", name: "GLM-4.7 Mock" }
+        ]
+      },
+      delayMilliseconds: 20
+    }
+  }]
+});
+httpMock.start();
+
+const runtime = createScenarioRuntime({
+  journal,
+  unmatchedResponse: "Type “fetch mocked catalog” to start.",
+  turns: [{
+    id: "fetch-model-catalog",
+    match: "fetch mocked catalog",
+    steps: [{
+      type: "respond",
+      response: async () => {
+        const response = await fetch("https://scenario.invalid/api/models", {
+          headers: { "x-scenario-client": "zcode-tui" }
+        });
+        if (!response.ok) throw new Error(`Mock catalog request failed with ${response.status}.`);
+        const payload = await response.json() as {
+          models: Array<{ id: string; name: string }>;
+        };
+        return `Mock catalog: ${payload.models.map((model) => model.name).join(", ")}`;
+      }
+    }]
+  }]
+});
+
+await runTui({
+  version: "http-mock-scenario",
+  workspaceDirectory: process.cwd(),
+  initialMode: "build",
+  initialModel: "scenario/model",
+  modelOptions: [{ alias: "main", id: "scenario/model", name: "Scenario" }],
+  loadSessionTranscript: async () => [
+    {
+      messageId: "scenario_instruction",
+      role: "agent",
+      content: "Type “fetch mocked catalog” to exercise a real fetch through the strict MSW boundary."
+    }
+  ],
+  submitPrompt: runtime.submitPrompt,
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr
+} as Parameters<typeof runTui>[0]);
+
+httpMock.assertSatisfied();

--- a/test/tui/harness/run-scenario.ts
+++ b/test/tui/harness/run-scenario.ts
@@ -13,13 +13,13 @@ export async function runAutomatedTuiScenario(scenario: TuiScenario): Promise<vo
   });
   try {
     await scenario.run(session, workspace);
+    await session.exit();
   } catch (error) {
     const runtimeJournal = await workspace.readRuntimeJournal();
     if (!runtimeJournal) throw error;
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`${message}\n\nRuntime journal:\n${runtimeJournal.trimEnd()}`, { cause: error });
   }
-  await session.exit();
 }
 
 export async function runManualTuiScenario(scenario: TuiScenario): Promise<number> {

--- a/test/tui/harness/terminal-session.ts
+++ b/test/tui/harness/terminal-session.ts
@@ -214,14 +214,19 @@ export class TerminalSession implements AsyncDisposable {
 
   async exit(): Promise<void> {
     if (this.#child.exitCode === null) this.send("/exit\r");
-    const exitCode = await Promise.race([
+    let exitCode = await Promise.race([
       this.#child.exited,
       Bun.sleep(2_000).then(() => undefined)
     ]);
     if (exitCode === undefined && this.#child.exitCode === null) {
       this.#child.kill("SIGKILL");
-      await this.#child.exited;
+      exitCode = await this.#child.exited;
+      this.journal.record("terminal.exit", { exitCode, timedOut: true });
+      throw new Error(`TUI fixture did not exit within 2000ms (exit code ${exitCode}).`);
     }
+    exitCode ??= this.#child.exitCode ?? undefined;
+    this.journal.record("terminal.exit", { exitCode, timedOut: false });
+    if (exitCode !== 0) throw new Error(`TUI fixture exited with code ${String(exitCode)}.`);
   }
 
   async dispose(): Promise<void> {

--- a/test/tui/http-mock.test.ts
+++ b/test/tui/http-mock.test.ts
@@ -1,0 +1,12 @@
+import { test } from "bun:test";
+
+import { runAutomatedTuiScenario } from "./harness/run-scenario.ts";
+import { httpMockScenario } from "./scenarios/http-mock.ts";
+
+test.skipIf(process.platform === "win32")(
+  "fixture fetches are intercepted inside the TUI child process",
+  async () => {
+    await runAutomatedTuiScenario(httpMockScenario);
+  },
+  35_000
+);

--- a/test/tui/runtime/scenario-http.ts
+++ b/test/tui/runtime/scenario-http.ts
@@ -1,0 +1,310 @@
+import {
+  HttpResponse,
+  http,
+  type HttpResponseInit,
+  type JsonBodyType
+} from "msw";
+import { setupServer, type SetupServer } from "msw/node";
+
+import { ScenarioRuntimeJournal } from "./scenario-runtime.ts";
+
+const REQUEST_BODY_JOURNAL_LIMIT = 16_384;
+const SENSITIVE_HEADER = /(?:authorization|cookie|token|api[-_]?key|secret)/iu;
+
+export type ScenarioHttpMethod =
+  | "ALL"
+  | "DELETE"
+  | "GET"
+  | "HEAD"
+  | "OPTIONS"
+  | "PATCH"
+  | "POST"
+  | "PUT";
+
+export interface ScenarioHttpRequestContext {
+  readonly call: number;
+  readonly cookies: Readonly<Record<string, string>>;
+  readonly params: Readonly<Record<string, string | readonly string[] | undefined>>;
+  readonly request: Request;
+  readonly routeId: string;
+  json<T = unknown>(): Promise<T>;
+  text(): Promise<string>;
+}
+
+export type ScenarioHttpValue<T> =
+  | T
+  | ((context: ScenarioHttpRequestContext) => T | Promise<T>);
+
+interface ScenarioHttpResponseBase extends Omit<HttpResponseInit, "type"> {
+  delayMilliseconds?: number;
+}
+
+export interface ScenarioHttpJsonResponse extends ScenarioHttpResponseBase {
+  type: "json";
+  body: JsonBodyType;
+}
+
+export interface ScenarioHttpTextResponse extends ScenarioHttpResponseBase {
+  type: "text";
+  body?: string;
+}
+
+export interface ScenarioHttpEmptyResponse extends ScenarioHttpResponseBase {
+  type: "empty";
+}
+
+export interface ScenarioHttpNetworkError {
+  type: "networkError";
+}
+
+export type ScenarioHttpResponse =
+  | ScenarioHttpEmptyResponse
+  | ScenarioHttpJsonResponse
+  | ScenarioHttpNetworkError
+  | ScenarioHttpTextResponse;
+
+export interface ScenarioHttpRoute {
+  id: string;
+  method: ScenarioHttpMethod;
+  url: string | RegExp;
+  expectedCalls?: number;
+  assert?: (context: ScenarioHttpRequestContext) => void | Promise<void>;
+  response: ScenarioHttpValue<ScenarioHttpResponse>;
+}
+
+export interface ScenarioHttpDefinition {
+  routes: readonly ScenarioHttpRoute[];
+  journal?: ScenarioRuntimeJournal;
+  journalPath?: string;
+}
+
+export interface ScenarioHttpMock extends Disposable {
+  readonly journal: ScenarioRuntimeJournal;
+  assertSatisfied(): void;
+  calls(routeId: string): number;
+  close(): void;
+  start(): void;
+}
+
+async function scenarioHttpValue<T>(
+  value: ScenarioHttpValue<T>,
+  context: ScenarioHttpRequestContext
+): Promise<T> {
+  if (typeof value !== "function") return value;
+  return await (value as (context: ScenarioHttpRequestContext) => T | Promise<T>)(context);
+}
+
+function validateDefinition(definition: ScenarioHttpDefinition): void {
+  if (definition.journal && definition.journalPath) {
+    throw new Error("Scenario HTTP mock accepts either journal or journalPath, not both.");
+  }
+  const ids = new Set<string>();
+  for (const route of definition.routes) {
+    if (!route.id || ids.has(route.id)) {
+      throw new Error(`Scenario HTTP route id must be unique: ${route.id || "(empty)"}`);
+    }
+    ids.add(route.id);
+    if (
+      route.expectedCalls !== undefined
+      && (!Number.isSafeInteger(route.expectedCalls) || route.expectedCalls < 0)
+    ) {
+      throw new Error(`Scenario HTTP route "${route.id}" has an invalid expectedCalls value.`);
+    }
+  }
+}
+
+function createRequestContext(
+  route: ScenarioHttpRoute,
+  request: Request,
+  params: Record<string, string | readonly string[] | undefined>,
+  cookies: Record<string, string>,
+  call: number
+): ScenarioHttpRequestContext {
+  return {
+    call,
+    cookies,
+    params,
+    request,
+    routeId: route.id,
+    async json<T = unknown>(): Promise<T> {
+      return await request.clone().json() as T;
+    },
+    async text(): Promise<string> {
+      return await request.clone().text();
+    }
+  };
+}
+
+async function requestDetail(
+  route: ScenarioHttpRoute,
+  request: Request,
+  call: number
+): Promise<Record<string, unknown>> {
+  const body = await request.clone().text();
+  const headers = Object.fromEntries(
+    [...request.headers].map(([name, value]) => [
+      name,
+      SENSITIVE_HEADER.test(name) ? "[redacted]" : value
+    ])
+  );
+  return {
+    body: body.length > REQUEST_BODY_JOURNAL_LIMIT
+      ? `${body.slice(0, REQUEST_BODY_JOURNAL_LIMIT)}…`
+      : body,
+    bodyTruncated: body.length > REQUEST_BODY_JOURNAL_LIMIT,
+    call,
+    headers,
+    method: request.method,
+    routeId: route.id,
+    url: request.url
+  };
+}
+
+function responseInit(response: ScenarioHttpResponseBase): HttpResponseInit {
+  const { delayMilliseconds: _, ...init } = response;
+  return init;
+}
+
+async function wait(milliseconds: number, signal: AbortSignal): Promise<void> {
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) {
+    throw new Error(`Scenario HTTP response has an invalid delay: ${milliseconds}`);
+  }
+  if (milliseconds === 0) return;
+  signal.throwIfAborted();
+  await new Promise<void>((resolveWait, reject) => {
+    const timer = setTimeout(finish, milliseconds);
+    const abort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", abort);
+      reject(signal.reason ?? new DOMException("Scenario HTTP request aborted", "AbortError"));
+    };
+    function finish() {
+      signal.removeEventListener("abort", abort);
+      resolveWait();
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function createResponse(response: ScenarioHttpResponse): Response {
+  if (response.type === "networkError") return HttpResponse.error();
+  const init = responseInit(response);
+  if (response.type === "json") return HttpResponse.json(response.body, init);
+  if (response.type === "text") return HttpResponse.text(response.body, init);
+  return new HttpResponse(null, init);
+}
+
+function responseDetail(response: ScenarioHttpResponse): Record<string, unknown> {
+  if (response.type === "networkError") return { type: response.type };
+  return {
+    delayMilliseconds: response.delayMilliseconds ?? 0,
+    status: response.status ?? 200,
+    type: response.type
+  };
+}
+
+export function createScenarioHttpMock(definition: ScenarioHttpDefinition): ScenarioHttpMock {
+  validateDefinition(definition);
+  const journal = definition.journal ?? new ScenarioRuntimeJournal(definition.journalPath);
+  const callCounts = new Map(definition.routes.map((route) => [route.id, 0]));
+  const executionFailures: string[] = [];
+
+  const handlers = definition.routes.map((route) => {
+    const method = route.method.toLowerCase() as Lowercase<ScenarioHttpMethod>;
+    const handler = method === "all" ? http.all : http[method];
+    return handler(route.url, async ({ request, params, cookies }) => {
+      const call = (callCounts.get(route.id) ?? 0) + 1;
+      callCounts.set(route.id, call);
+      journal.record("http.request", await requestDetail(route, request, call));
+      const context = createRequestContext(route, request, params, cookies, call);
+      try {
+        if (route.expectedCalls !== undefined && call > route.expectedCalls) {
+          throw new Error(
+            `Scenario HTTP route "${route.id}" expected ${route.expectedCalls} call(s), received at least ${call}.`
+          );
+        }
+        await route.assert?.(context);
+        const response = await scenarioHttpValue(route.response, context);
+        if (response.type !== "networkError") {
+          await wait(response.delayMilliseconds ?? 0, request.signal);
+        }
+        journal.record("http.response", {
+          ...responseDetail(response),
+          call,
+          routeId: route.id
+        });
+        return createResponse(response);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (request.signal.aborted) {
+          journal.record("http.abort", {
+            call,
+            error: message,
+            routeId: route.id
+          });
+          return HttpResponse.error();
+        }
+        executionFailures.push(`"${route.id}": ${message}`);
+        journal.record("http.error", {
+          call,
+          error: message,
+          routeId: route.id
+        });
+        return HttpResponse.error();
+      }
+    });
+  });
+
+  const server: SetupServer = setupServer(...handlers);
+  let started = false;
+
+  return {
+    journal,
+    assertSatisfied(): void {
+      const failures = [...executionFailures, ...definition.routes.flatMap((route) => {
+        if (route.expectedCalls === undefined) return [];
+        const actual = callCounts.get(route.id) ?? 0;
+        return actual === route.expectedCalls
+          ? []
+          : [`"${route.id}" expected ${route.expectedCalls}, received ${actual}`];
+      })];
+      journal.record("http.assert", { failures });
+      if (failures.length > 0) {
+        throw new Error(`Scenario HTTP expectations failed: ${failures.join("; ")}`);
+      }
+    },
+    calls(routeId: string): number {
+      if (!callCounts.has(routeId)) throw new Error(`Unknown scenario HTTP route: ${routeId}`);
+      return callCounts.get(routeId) ?? 0;
+    },
+    close(): void {
+      if (!started) return;
+      server.close();
+      started = false;
+      journal.record("http.close", {});
+    },
+    start(): void {
+      if (started) throw new Error("Scenario HTTP mock is already started.");
+      server.listen({
+        onUnhandledRequest(request) {
+          const detail = { method: request.method, url: request.url };
+          executionFailures.push(`unhandled ${request.method} ${request.url}`);
+          journal.record("http.unhandled", detail);
+          throw new Error(`Unhandled scenario HTTP request: ${request.method} ${request.url}`);
+        }
+      });
+      started = true;
+      journal.record("http.start", {
+        routes: definition.routes.map((route) => ({
+          expectedCalls: route.expectedCalls,
+          id: route.id,
+          method: route.method,
+          url: String(route.url)
+        }))
+      });
+    },
+    [Symbol.dispose](): void {
+      this.close();
+    }
+  };
+}

--- a/test/tui/runtime/scenario-runtime.ts
+++ b/test/tui/runtime/scenario-runtime.ts
@@ -57,6 +57,7 @@ export interface ScenarioTurn {
 export interface ScenarioRuntimeDefinition {
   turns: readonly ScenarioTurn[];
   workspaceDirectory?: string;
+  journal?: ScenarioRuntimeJournal;
   journalPath?: string;
   unmatchedResponse?: ScenarioValue<string>;
 }
@@ -141,6 +142,9 @@ function workspacePath(workspaceDirectory: string, path: string): string {
 }
 
 function validateDefinition(definition: ScenarioRuntimeDefinition): void {
+  if (definition.journal && definition.journalPath) {
+    throw new Error("Scenario runtime accepts either journal or journalPath, not both.");
+  }
   const ids = new Set<string>();
   for (const turn of definition.turns) {
     if (!turn.id || ids.has(turn.id)) throw new Error(`Scenario turn id must be unique: ${turn.id || "(empty)"}`);
@@ -162,7 +166,7 @@ function validateDefinition(definition: ScenarioRuntimeDefinition): void {
 
 export function createScenarioRuntime(definition: ScenarioRuntimeDefinition): ScenarioRuntimeAdapter {
   validateDefinition(definition);
-  const journal = new ScenarioRuntimeJournal(definition.journalPath);
+  const journal = definition.journal ?? new ScenarioRuntimeJournal(definition.journalPath);
 
   const submitPrompt = async (input: unknown, options: PromptCallOptions): Promise<unknown> => {
     throwIfAborted(options.abortSignal);

--- a/test/tui/scenario-http.test.ts
+++ b/test/tui/scenario-http.test.ts
@@ -1,0 +1,159 @@
+import { expect, test } from "bun:test";
+
+import { ScenarioRuntimeJournal } from "./runtime/scenario-runtime.ts";
+import { createScenarioHttpMock } from "./runtime/scenario-http.ts";
+
+test("scenario HTTP mock intercepts real fetch calls and validates typed requests", async () => {
+  const journal = new ScenarioRuntimeJournal();
+  using mock = createScenarioHttpMock({
+    journal,
+    routes: [{
+      id: "update-model",
+      method: "POST",
+      url: "https://scenario.invalid/api/models/:modelId",
+      expectedCalls: 1,
+      async assert(context) {
+        expect(context.params.modelId).toBe("glm-5");
+        expect(await context.json<{ enabled: boolean }>()).toEqual({ enabled: true });
+        expect(context.request.headers.get("authorization")).toBe("Bearer fixture-token");
+      },
+      response: (context) => ({
+        type: "json",
+        body: {
+          call: context.call,
+          modelId: context.params.modelId,
+          updated: true
+        },
+        headers: { "x-scenario": "mocked" },
+        status: 202
+      })
+    }]
+  });
+  mock.start();
+
+  const response = await fetch("https://scenario.invalid/api/models/glm-5", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer fixture-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ enabled: true })
+  });
+
+  expect(response.status).toBe(202);
+  expect(response.headers.get("x-scenario")).toBe("mocked");
+  expect(await response.json()).toEqual({ call: 1, modelId: "glm-5", updated: true });
+  expect(mock.calls("update-model")).toBe(1);
+  mock.assertSatisfied();
+  expect(journal.entries().map((entry) => entry.kind)).toEqual([
+    "http.start",
+    "http.request",
+    "http.response",
+    "http.assert"
+  ]);
+  expect(journal.entries()[1]).toMatchObject({
+    detail: {
+      headers: { authorization: "[redacted]" }
+    }
+  });
+});
+
+test("scenario HTTP mock rejects unhandled requests and records the failure", async () => {
+  using mock = createScenarioHttpMock({ routes: [] });
+  mock.start();
+
+  expect((await fetch("https://scenario.invalid/unhandled")).status).toBe(500);
+  expect(mock.journal.entries().at(-1)).toMatchObject({
+    kind: "http.unhandled",
+    detail: {
+      method: "GET",
+      url: "https://scenario.invalid/unhandled"
+    }
+  });
+  expect(() => mock.assertSatisfied()).toThrow(
+    "unhandled GET https://scenario.invalid/unhandled"
+  );
+});
+
+test("scenario HTTP mock reports missing, excess, and unknown route calls", async () => {
+  using mock = createScenarioHttpMock({
+    routes: [{
+      id: "once",
+      method: "GET",
+      url: "https://scenario.invalid/once",
+      expectedCalls: 1,
+      response: { type: "empty", status: 204 }
+    }]
+  });
+  mock.start();
+
+  expect(() => mock.assertSatisfied()).toThrow('"once" expected 1, received 0');
+  expect(() => mock.calls("missing")).toThrow("Unknown scenario HTTP route");
+  expect((await fetch("https://scenario.invalid/once")).status).toBe(204);
+  await expect(fetch("https://scenario.invalid/once")).rejects.toThrow();
+  expect(() => mock.assertSatisfied()).toThrow('"once" expected 1, received 2');
+});
+
+test("scenario HTTP mock supports latency, cancellation, and network errors", async () => {
+  using mock = createScenarioHttpMock({
+    routes: [{
+      id: "delayed",
+      method: "GET",
+      url: "https://scenario.invalid/delayed",
+      response: {
+        type: "text",
+        body: "too late",
+        delayMilliseconds: 5_000
+      }
+    }, {
+      id: "offline",
+      method: "GET",
+      url: "https://scenario.invalid/offline",
+      response: { type: "networkError" }
+    }]
+  });
+  mock.start();
+
+  const controller = new AbortController();
+  const delayed = fetch("https://scenario.invalid/delayed", { signal: controller.signal });
+  controller.abort(new Error("scenario cancelled"));
+  await expect(delayed).rejects.toThrow("scenario cancelled");
+  await expect(fetch("https://scenario.invalid/offline")).rejects.toThrow();
+  mock.assertSatisfied();
+  expect(mock.journal.entries()).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      kind: "http.abort",
+      detail: expect.objectContaining({ routeId: "delayed" })
+    }),
+    expect.objectContaining({
+      kind: "http.response",
+      detail: expect.objectContaining({ routeId: "offline", type: "networkError" })
+    })
+  ]));
+});
+
+test("scenario HTTP mock rejects ambiguous definitions", () => {
+  expect(() => createScenarioHttpMock({
+    routes: [{
+      id: "duplicate",
+      method: "GET",
+      url: "https://scenario.invalid/one",
+      response: { type: "empty" }
+    }, {
+      id: "duplicate",
+      method: "GET",
+      url: "https://scenario.invalid/two",
+      response: { type: "empty" }
+    }]
+  })).toThrow("route id must be unique");
+
+  expect(() => createScenarioHttpMock({
+    routes: [{
+      id: "invalid-count",
+      method: "GET",
+      url: "https://scenario.invalid/count",
+      expectedCalls: -1,
+      response: { type: "empty" }
+    }]
+  })).toThrow("invalid expectedCalls");
+});

--- a/test/tui/scenarios/http-mock.ts
+++ b/test/tui/scenarios/http-mock.ts
@@ -1,0 +1,28 @@
+import { join } from "node:path";
+
+import type { TuiScenario } from "./types.ts";
+
+export const httpMockScenario: TuiScenario = {
+  name: "http-mock",
+  description: "Intercepts a fixture fetch through a strict, typed MSW boundary.",
+  fixture: join(import.meta.dir, "..", "fixtures", "http-mock.ts"),
+  async run(session, workspace) {
+    await session.waitForScreen(
+      "scenario instructions",
+      /Type “fetch mocked catalog” to exercise a real fetch/iu,
+      20_000
+    );
+    await session.sendAndWait(
+      "fetch mocked catalog\r",
+      "mocked model catalog",
+      /Mock catalog: GLM-5 Mock, GLM-4\.7 Mock/iu
+    );
+    const runtimeJournal = await workspace.readRuntimeJournal();
+    if (
+      !runtimeJournal.includes('"kind":"http.request"')
+      || !runtimeJournal.includes('"kind":"http.response"')
+    ) {
+      throw new Error(`The child fixture did not journal its mocked fetch.\n${runtimeJournal}`);
+    }
+  }
+};

--- a/test/tui/scenarios/index.ts
+++ b/test/tui/scenarios/index.ts
@@ -1,8 +1,10 @@
+import { httpMockScenario } from "./http-mock.ts";
 import { permissionRequestQueueScenario } from "./permission-request-queue.ts";
 import type { TuiScenario } from "./types.ts";
 import { writeAndDiffScenario } from "./write-and-diff.ts";
 
 const scenarios = new Map<string, TuiScenario>([
+  [httpMockScenario.name, httpMockScenario],
   [permissionRequestQueueScenario.name, permissionRequestQueueScenario],
   [writeAndDiffScenario.name, writeAndDiffScenario]
 ]);

--- a/test/tui/terminal-session.test.ts
+++ b/test/tui/terminal-session.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { ScenarioWorkspace } from "./harness/scenario-workspace.ts";
+import { TerminalSession } from "./harness/terminal-session.ts";
+
+test.skipIf(process.platform === "win32")(
+  "terminal sessions reject a non-zero fixture exit",
+  async () => {
+    await using workspace = await ScenarioWorkspace.create();
+    await using session = TerminalSession.start({
+      command: [process.execPath, "-e", "process.exit(7)"],
+      workspace
+    });
+
+    await expect(session.exit()).rejects.toThrow("TUI fixture exited with code 7");
+    expect(session.journal.format()).toContain('terminal.exit {"exitCode":7,"timedOut":false}');
+  }
+);


### PR DESCRIPTION
## Summary

- add a typed MSW-backed HTTP scenario layer that intercepts real fixture `fetch` calls
- support request assertions, exact call counts, JSON/text/empty responses, latency, cancellation, and network failures
- reject and journal unhandled requests while redacting sensitive request headers
- add an automated/manual TUI child-process scenario using a shared runtime and HTTP journal
- fail automated scenarios when a fixture times out or exits non-zero, including runtime diagnostics from exit failures
- document the network backend contract and add focused coverage

## Test plan

- `bun run typecheck`
- `bun run test:tui-scenario --list`
- `bun test test/tui/scenario-http.test.ts test/tui/http-mock.test.ts test/tui/terminal-session.test.ts`
- `TMPDIR=/tmp bun run test:all`
- `bun run build`
- `git diff --check`

## Results

- Fast: 647 passed
- TUI: 20 passed
- Runtime: 13 passed