### PR TITLE
test(tui): add shell and Mountx backends

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,8 @@
         "bun-types": "^1.3.14",
         "cli-highlight": "^2.1.11",
         "diff": "^9.0.0",
+        "just-bash": "^3.4.2",
+        "mountx": "^0.0.2",
         "msw": "^2.15.0",
         "tsdown": "^0.22.7",
         "typescript": "^7.0.2",
@@ -22,6 +24,8 @@
     },
   },
   "packages": {
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
     "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
@@ -40,9 +44,25 @@
 
     "@inquirer/type": ["@inquirer/type@4.1.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yJoHYrMnxIsJZCY+0Vb66Dy3he3kL3e2wOBKhoSwWWAzZAY82emlxwgprCtp6yRixvNRNq9ztfRWQYPNr3Go7A=="],
 
+    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
+
+    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
+
+    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
+
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.9", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
 
@@ -85,6 +105,10 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -190,13 +214,27 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
@@ -208,9 +246,19 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
@@ -222,9 +270,13 @@
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
@@ -232,13 +284,23 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.11.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.5", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
 
@@ -250,13 +312,37 @@
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
+    "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
+
+    "just-bash": ["just-bash@3.4.2", "", { "dependencies": { "diff": "^8.0.4", "fast-xml-parser": "^5.10.1", "file-type": "^21.3.4", "ini": "^6.0.0", "minimatch": "^10.2.6", "modern-tar": "^0.7.7", "papaparse": "^5.6.0", "quickjs-emscripten": "^0.32.0", "re2js": "^1.3.3", "seek-bzip": "^2.0.0", "smol-toml": "^1.8.0", "sprintf-js": "^1.1.3", "sql.js": "^1.14.1", "turndown": "^7.2.4", "undici": "^7.29.0", "yaml": "^2.9.0" }, "optionalDependencies": { "@mongodb-js/zstd": "^7.0.0", "node-liblzma": "^2.2.0" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg=="],
+
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
+
+    "mountx": ["mountx@0.0.2", "", { "peerDependencies": { "unstorage": "*" }, "optionalPeers": ["unstorage"], "bin": { "mountx": "dist/cli/index.mjs" } }, "sha512-9e9DB2zUA0gCk5d7EzaN4o4+R8+36Fn7NzEhCibe8FlaN3xDC9JtDcEotI3q++ENOcxzByzIPIOoiztZn/TIUg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.15.0", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.11", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ=="],
 
@@ -264,15 +350,31 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "node-abi": ["node-abi@3.96.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg=="],
+
+    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
+    "papaparse": ["papaparse@5.7.0", "", {}, "sha512-qBGxg/7Q3Kl9Wfhrz2Z74UnvnHTXLNG6jmKJFeBvP2+y4lV7So+7SR62+Zd47JvdrCkX+nDcnr0ObPzek/+6RA=="],
 
     "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -282,7 +384,21 @@
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
+
+    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "re2js": ["re2js@1.4.0", "", {}, "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -294,11 +410,25 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.9", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3", "yuku-ast": "^0.1.7", "yuku-codegen": "^0.6.1", "yuku-parser": "^0.6.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": "*", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-d54yt65+ZF/Mk8H6P36As02PAMdaiWRSzVNtJRc1h7nCgUFjuRI4cN2DyTfJyfVpPH6pgy7/2D7YQH1/Rh75Yg=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "seek-bzip": ["seek-bzip@2.0.0", "", { "dependencies": { "commander": "^6.0.0" }, "bin": { "seek-bunzip": "bin/seek-bunzip", "seek-table": "bin/seek-bzip-table" } }, "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "sql.js": ["sql.js@1.14.2", "", {}, "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -306,11 +436,23 @@
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strnum": ["strnum@2.4.2", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -324,6 +466,8 @@
 
     "tldts-core": ["tldts-core@7.4.12", "", {}, "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
@@ -332,17 +476,31 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
     "type-fest": ["type-fest@5.9.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
+
+    "undici": ["undici@7.29.1", "", {}, "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -360,9 +518,13 @@
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
+    "just-bash/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
     "msw/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/docs/TUI_SCENARIO_TESTING.md
+++ b/docs/TUI_SCENARIO_TESTING.md
@@ -44,6 +44,11 @@ bun run test:tui-scenario permission-request-queue
 # Open the same scenario for manual interaction.
 bun run test:tui:manual permission-request-queue
 
+# Exercise an allowlisted shell against the normal temporary workspace.
+bun run test:tui:manual allowlisted-shell
+
+# Opt into a kernel-mounted in-memory workspace when Mountx supports the host.
+bun run test:tui:manual allowlisted-shell --workspace-backend=mountx
 ```
 
 Manual mode prints the temporary workspace path before opening the TUI. Enter
@@ -65,6 +70,10 @@ Manual mode prints the temporary workspace path before opening the TUI. Enter
   event, delay, permission, file-write, and response steps.
 - `test/tui/runtime/scenario-http.ts` maps declared MSW routes to real fixture
   `fetch` calls, request assertions, responses, and exact call counts.
+- `test/tui/runtime/scenario-shell.ts` runs bounded, allowlisted just-bash
+  commands against the selected scenario workspace.
+- `test/tui/harness/mountx-workspace-backend.ts` provides an explicitly
+  requested in-memory kernel mount when the host has a usable transport.
 - `scripts/tui-scenario.ts` exposes automatic and manual execution modes.
 
 A scenario should describe behavior rather than terminal timing. Use
@@ -125,14 +134,41 @@ Call `httpMock.start()` before `runTui()`, call `httpMock.assertSatisfied()`
 after it exits, and use `using` or `close()` to restore the process network
 state. Do not allow unhandled requests to reach the public network.
 
-Additional backends should preserve the same scenario contract:
+Shell scenarios use `createScenarioShell()` with just-bash's hardened execution
+limits, a fixed command allowlist, no network, no JavaScript or Python runtime,
+and a `ReadWriteFs` rooted at the scenario workspace. Writes therefore remain
+visible to the TUI's real Git diff. Native Git is deliberately absent from the
+shell; Git assertions continue through `ScenarioWorkspace.git()` with the
+isolated configuration described above. just-bash executes in the fixture
+process and is not a VM or container security boundary.
 
-- Mountx may provide an optional in-memory mounted workspace for filesystem
-  journaling and fault injection. It must not be treated as a sandbox.
-- just-bash may execute allowlisted shell behavior against the scenario
-  workspace. It should not expose unrestricted host commands or native Git.
-- Scenarios requiring arbitrary binaries, Git hooks, or untrusted code belong
-  in a container backend.
+The default workspace backend remains a normal temporary directory because it
+is portable and exercises the fewest layers. `--workspace-backend=mountx`
+replaces only that directory with Mountx's in-memory driver mounted through the
+host's selected transport. `MountxWorkspaceBackend` also accepts a custom
+Mountx driver for operation journaling or deterministic fault injection. The
+backend is opt-in because Mountx is alpha, requires OS mount support, and
+exposes the mount to other host processes. It is not a sandbox.
+The gated integration check can be run explicitly:
+
+```bash
+ZCODE_TEST_MOUNTX=1 bun test test/tui/scenario-mountx.test.ts
+```
+
+The completed backend boundary is:
+
+| Need | Backend |
+| --- | --- |
+| Runtime responses and permission ordering | Typed scenario runtime |
+| Deterministic `fetch` behavior | Strict child-process MSW |
+| Common shell syntax and workspace writes | Allowlisted just-bash |
+| Portable filesystem and real Git behavior | Temporary disk workspace |
+| Kernel mount behavior or filesystem-driver faults | Opt-in Mountx workspace |
+| Arbitrary binaries, Git hooks, or untrusted code | External container/VM |
+
+Do not add host command passthrough to just-bash or treat Mountx as containment.
+A scenario that crosses those constraints must move to an external
+container/VM runtime test instead of weakening the hermetic TUI suite.
 
 ## Adding a scenario
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "bun-types": "^1.3.14",
     "cli-highlight": "^2.1.11",
     "diff": "^9.0.0",
+    "just-bash": "^3.4.2",
+    "mountx": "^0.0.2",
     "msw": "^2.15.0",
     "tsdown": "^0.22.7",
     "typescript": "^7.0.2",

--- a/scripts/smoke-tui.ts
+++ b/scripts/smoke-tui.ts
@@ -176,6 +176,10 @@ try {
   }
   // The first-run setup wizard opens over the composer; skip it explicitly
   // (Esc) so the rest of the scripted interaction reaches the editor.
+  await waitFor(
+    "first-run setup wizard",
+    /Welcome to ZCode CLI[\s\S]*Set up model access to get started\.[\s\S]*Skip for now/i
+  );
   await sendAndWait("\x1b", "first-run setup wizard skipped", /Setup skipped/i);
   await sendAndWait(
     "@bro",

--- a/scripts/tui-scenario.ts
+++ b/scripts/tui-scenario.ts
@@ -1,9 +1,21 @@
 #!/usr/bin/env bun
 
 import { findTuiScenario, listTuiScenarios } from "../test/tui/scenarios/index.ts";
-import { runAutomatedTuiScenario, runManualTuiScenario } from "../test/tui/harness/run-scenario.ts";
+import {
+  runAutomatedTuiScenario,
+  runManualTuiScenario,
+  type ScenarioWorkspaceBackendName
+} from "../test/tui/harness/run-scenario.ts";
 
 const args = process.argv.slice(2);
+const workspaceBackendArgument = args.find((arg) => arg.startsWith("--workspace-backend="));
+const workspaceBackend = workspaceBackendArgument?.slice("--workspace-backend=".length) ?? "disk";
+if (workspaceBackend !== "disk" && workspaceBackend !== "mountx") {
+  throw new Error(`Unknown workspace backend "${workspaceBackend}". Expected disk or mountx.`);
+}
+const runOptions = {
+  workspaceBackend: workspaceBackend as ScenarioWorkspaceBackendName
+};
 if (args.includes("--list")) {
   for (const scenario of listTuiScenarios()) {
     console.log(`${scenario.name}\t${scenario.description}`);
@@ -16,7 +28,7 @@ const all = args.includes("--all");
 if (manual && all) throw new Error("--manual requires one scenario and cannot be combined with --all.");
 if (all) {
   for (const scenario of listTuiScenarios()) {
-    await runAutomatedTuiScenario(scenario);
+    await runAutomatedTuiScenario(scenario, runOptions);
     console.log(`TUI scenario passed: ${scenario.name}`);
   }
   process.exit(0);
@@ -25,8 +37,8 @@ const name = args.find((arg) => !arg.startsWith("-")) ?? "permission-request-que
 const scenario = findTuiScenario(name);
 
 if (manual) {
-  process.exitCode = await runManualTuiScenario(scenario);
+  process.exitCode = await runManualTuiScenario(scenario, runOptions);
 } else {
-  await runAutomatedTuiScenario(scenario);
+  await runAutomatedTuiScenario(scenario, runOptions);
   console.log(`TUI scenario passed: ${scenario.name}`);
 }

--- a/test/tui/allowlisted-shell.test.ts
+++ b/test/tui/allowlisted-shell.test.ts
@@ -1,0 +1,12 @@
+import { test } from "bun:test";
+
+import { runAutomatedTuiScenario } from "./harness/run-scenario.ts";
+import { allowlistedShellScenario } from "./scenarios/allowlisted-shell.ts";
+
+test.skipIf(process.platform === "win32")(
+  "allowlisted shell writes render through the TUI real Git diff",
+  async () => {
+    await runAutomatedTuiScenario(allowlistedShellScenario);
+  },
+  35_000
+);

--- a/test/tui/fixtures/allowlisted-shell.ts
+++ b/test/tui/fixtures/allowlisted-shell.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+
+import { runTui } from "../../../packages/zcode-tui/src/index.ts";
+import {
+  createScenarioRuntime,
+  ScenarioRuntimeJournal
+} from "../runtime/scenario-runtime.ts";
+import { createScenarioShell } from "../runtime/scenario-shell.ts";
+
+function permissionAllowed(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  return (value as Record<string, unknown>).decision === "allow";
+}
+
+const journal = new ScenarioRuntimeJournal(
+  process.env.ZCODE_TUI_SCENARIO_RUNTIME_JOURNAL
+);
+const shell = createScenarioShell({
+  journal,
+  workspaceDirectory: process.cwd()
+});
+const command = "mkdir -p reports && printf 'alpha\\nbeta\\n' | tee reports/shell.txt | wc -l";
+const runtime = createScenarioRuntime({
+  journal,
+  unmatchedResponse: "Type “run allowlisted shell” to start.",
+  turns: [{
+    id: "run-allowlisted-shell",
+    match: "run allowlisted shell",
+    steps: [{
+      type: "permissions",
+      requests: [{
+        toolCallId: "scenario_allowlisted_shell",
+        toolName: "Bash",
+        reason: "ALLOWLISTED_SHELL_WRITE",
+        input: { command }
+      }],
+      saveAs: "permissions"
+    }, {
+      type: "respond",
+      response: async (context) => {
+        const [decision] = context.value<unknown[]>("permissions");
+        if (!permissionAllowed(decision)) return "Allowlisted shell cancelled.";
+        const result = await shell.exec(command, {
+          signal: context.options.abortSignal
+        });
+        return `Allowlisted shell complete: ${result.stdout.trim()} lines.`;
+      }
+    }]
+  }]
+});
+
+await runTui({
+  version: "allowlisted-shell-scenario",
+  workspaceDirectory: process.cwd(),
+  initialMode: "build",
+  initialModel: "scenario/model",
+  modelOptions: [{ alias: "main", id: "scenario/model", name: "Scenario" }],
+  loadSessionTranscript: async () => [
+    {
+      messageId: "scenario_instruction",
+      role: "agent",
+      content: "Type “run allowlisted shell” to execute a bounded just-bash command."
+    }
+  ],
+  submitPrompt: runtime.submitPrompt,
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr
+} as Parameters<typeof runTui>[0]);

--- a/test/tui/harness/mountx-workspace-backend.ts
+++ b/test/tui/harness/mountx-workspace-backend.ts
@@ -1,0 +1,55 @@
+import {
+  mount,
+  probeTransports,
+  type AutoMount,
+  type AutoProbe
+} from "mountx/auto";
+import { createMemoryDriver } from "mountx/drivers/memory";
+import type { FsDriver } from "mountx";
+
+import type { ScenarioWorkspaceBackend } from "./scenario-workspace.ts";
+
+export class ScenarioMountxUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`Mountx workspace backend is unavailable: ${reason}`);
+    this.name = "ScenarioMountxUnavailableError";
+  }
+}
+
+export async function probeScenarioMountx(): Promise<AutoProbe> {
+  return await probeTransports();
+}
+
+export interface MountxWorkspaceBackendOptions {
+  driver?: FsDriver;
+  name?: string;
+}
+
+export class MountxWorkspaceBackend implements ScenarioWorkspaceBackend {
+  readonly name: string;
+  readonly #driver: FsDriver;
+  #mounted?: AutoMount;
+
+  constructor(options: MountxWorkspaceBackendOptions = {}) {
+    this.name = options.name ?? (options.driver ? "mountx-custom" : "mountx-memory");
+    this.#driver = options.driver ?? createMemoryDriver();
+  }
+
+  async mount(directory: string): Promise<void> {
+    if (this.#mounted) throw new Error("Mountx workspace backend is already mounted.");
+    const probe = await probeScenarioMountx();
+    if (!probe.chosen) {
+      throw new ScenarioMountxUnavailableError(probe.reason ?? "no usable transport");
+    }
+    this.#mounted = await mount(this.#driver, directory, {
+      signals: false,
+      transport: probe.chosen
+    });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.#mounted) return;
+    await this.#mounted.unmount();
+    this.#mounted = undefined;
+  }
+}

--- a/test/tui/harness/run-scenario.ts
+++ b/test/tui/harness/run-scenario.ts
@@ -2,11 +2,31 @@ import type { TuiScenario } from "../scenarios/types.ts";
 import { ScenarioWorkspace } from "./scenario-workspace.ts";
 import { TerminalSession } from "./terminal-session.ts";
 
-export async function runAutomatedTuiScenario(scenario: TuiScenario): Promise<void> {
-  await using workspace = await ScenarioWorkspace.create({
+export type ScenarioWorkspaceBackendName = "disk" | "mountx";
+
+export interface RunTuiScenarioOptions {
+  workspaceBackend?: ScenarioWorkspaceBackendName;
+}
+
+async function createScenarioWorkspace(
+  scenario: TuiScenario,
+  options: RunTuiScenarioOptions
+): Promise<ScenarioWorkspace> {
+  const backend = options.workspaceBackend === "mountx"
+    ? new (await import("./mountx-workspace-backend.ts")).MountxWorkspaceBackend()
+    : undefined;
+  return await ScenarioWorkspace.create({
+    backend,
     files: scenario.files,
     prefix: `zcode-${scenario.name}-`
   });
+}
+
+export async function runAutomatedTuiScenario(
+  scenario: TuiScenario,
+  options: RunTuiScenarioOptions = {}
+): Promise<void> {
+  await using workspace = await createScenarioWorkspace(scenario, options);
   await using session = TerminalSession.start({
     command: [process.execPath, scenario.fixture],
     workspace
@@ -22,12 +42,13 @@ export async function runAutomatedTuiScenario(scenario: TuiScenario): Promise<vo
   }
 }
 
-export async function runManualTuiScenario(scenario: TuiScenario): Promise<number> {
-  await using workspace = await ScenarioWorkspace.create({
-    files: scenario.files,
-    prefix: `zcode-${scenario.name}-`
-  });
+export async function runManualTuiScenario(
+  scenario: TuiScenario,
+  options: RunTuiScenarioOptions = {}
+): Promise<number> {
+  await using workspace = await createScenarioWorkspace(scenario, options);
   console.error(`Scenario: ${scenario.name}`);
+  console.error(`Workspace backend: ${workspace.backendName}`);
   console.error(`Workspace: ${workspace.directory}`);
   console.error("Exit the TUI with /exit. The workspace will then be deleted.");
   const child = Bun.spawn([process.execPath, scenario.fixture], {

--- a/test/tui/harness/scenario-workspace.ts
+++ b/test/tui/harness/scenario-workspace.ts
@@ -6,7 +6,14 @@ import { ScenarioJournal } from "./scenario-journal.ts";
 
 const gitTimeoutMilliseconds = 10_000;
 
+export interface ScenarioWorkspaceBackend {
+  readonly name: string;
+  dispose(): Promise<void>;
+  mount(directory: string): Promise<void>;
+}
+
 export interface ScenarioWorkspaceOptions {
+  backend?: ScenarioWorkspaceBackend;
   files?: Record<string, string | Uint8Array>;
   journal?: ScenarioJournal;
   prefix?: string;
@@ -25,22 +32,47 @@ export class ScenarioWorkspace implements AsyncDisposable {
   readonly home: string;
   readonly journal: ScenarioJournal;
   readonly runtimeJournalPath: string;
+  readonly backendName: string;
+  readonly #backend?: ScenarioWorkspaceBackend;
+  #disposed = false;
 
-  private constructor(root: string, journal: ScenarioJournal) {
+  private constructor(
+    root: string,
+    journal: ScenarioJournal,
+    backend?: ScenarioWorkspaceBackend
+  ) {
     this.root = root;
     this.directory = join(root, "workspace");
     this.gitDirectory = join(root, "git");
     this.home = join(root, "home");
     this.journal = journal;
     this.runtimeJournalPath = join(root, "runtime.jsonl");
+    this.backendName = backend?.name ?? "disk";
+    this.#backend = backend;
   }
 
   static async create(options: ScenarioWorkspaceOptions = {}): Promise<ScenarioWorkspace> {
     const root = await mkdtemp(join(tmpdir(), options.prefix ?? "zcode-tui-scenario-"));
-    const workspace = new ScenarioWorkspace(root, options.journal ?? new ScenarioJournal());
-    workspace.journal.record("workspace.create", { root });
+    const workspace = new ScenarioWorkspace(
+      root,
+      options.journal ?? new ScenarioJournal(),
+      options.backend
+    );
+    workspace.journal.record("workspace.create", {
+      backend: workspace.backendName,
+      root
+    });
     try {
       await mkdir(workspace.directory, { recursive: true });
+      if (options.backend) {
+        workspace.journal.record("workspace.backend.mount.start", {
+          backend: options.backend.name
+        });
+        await options.backend.mount(workspace.directory);
+        workspace.journal.record("workspace.backend.mount.finish", {
+          backend: options.backend.name
+        });
+      }
       await mkdir(workspace.home, { recursive: true });
       for (const [path, contents] of Object.entries(options.files ?? {})) {
         await workspace.write(path, contents);
@@ -152,8 +184,14 @@ export class ScenarioWorkspace implements AsyncDisposable {
   }
 
   async dispose(): Promise<void> {
-    this.journal.record("workspace.dispose", { root: this.root });
+    if (this.#disposed) return;
+    this.journal.record("workspace.dispose", {
+      backend: this.backendName,
+      root: this.root
+    });
+    await this.#backend?.dispose();
     await rm(this.root, { recursive: true, force: true });
+    this.#disposed = true;
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/test/tui/runtime/scenario-shell.ts
+++ b/test/tui/runtime/scenario-shell.ts
@@ -1,0 +1,180 @@
+import {
+  Bash,
+  ReadWriteFs,
+  type BashOptions,
+  type CommandName
+} from "just-bash";
+
+import { ScenarioRuntimeJournal } from "./scenario-runtime.ts";
+
+const OUTPUT_JOURNAL_LIMIT = 16_384;
+type ExecutionLimits = NonNullable<BashOptions["executionLimits"]>;
+
+export const DEFAULT_SCENARIO_SHELL_COMMANDS = [
+  "basename",
+  "cat",
+  "cp",
+  "cut",
+  "dirname",
+  "echo",
+  "find",
+  "grep",
+  "head",
+  "jq",
+  "ls",
+  "mkdir",
+  "mv",
+  "printf",
+  "pwd",
+  "rm",
+  "sed",
+  "sort",
+  "tail",
+  "tee",
+  "touch",
+  "tr",
+  "uniq",
+  "wc"
+] as const satisfies readonly CommandName[];
+
+const DEFAULT_EXECUTION_LIMITS: ExecutionLimits = {
+  maxCommandCount: 2_000,
+  maxExecutionTimeMs: 5_000,
+  maxInputBytes: 2 * 1024 * 1024,
+  maxLoopIterations: 10_000,
+  maxOutputSize: 2 * 1024 * 1024,
+  maxSourceBytes: 256 * 1024,
+  maxTraversalEntries: 20_000
+};
+
+export interface ScenarioShellDefinition {
+  workspaceDirectory: string;
+  commands?: readonly CommandName[];
+  env?: Readonly<Record<string, string>>;
+  executionLimits?: ExecutionLimits;
+  journal?: ScenarioRuntimeJournal;
+  journalPath?: string;
+}
+
+export interface ScenarioShellExecOptions {
+  cwd?: string;
+  env?: Readonly<Record<string, string>>;
+  expectedExitCode?: number | readonly number[];
+  signal?: AbortSignal;
+  stdin?: string;
+}
+
+export interface ScenarioShellResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+export interface ScenarioShell {
+  readonly journal: ScenarioRuntimeJournal;
+  exec(command: string, options?: ScenarioShellExecOptions): Promise<ScenarioShellResult>;
+}
+
+function journalText(value: string): { text: string; truncated: boolean } {
+  return {
+    text: value.length > OUTPUT_JOURNAL_LIMIT
+      ? `${value.slice(0, OUTPUT_JOURNAL_LIMIT)}…`
+      : value,
+    truncated: value.length > OUTPUT_JOURNAL_LIMIT
+  };
+}
+
+function expectedExitCodes(value: number | readonly number[] | undefined): readonly number[] {
+  const codes = value === undefined ? [0] : typeof value === "number" ? [value] : value;
+  if (
+    codes.length === 0
+    || codes.some((code) => !Number.isSafeInteger(code) || code < 0 || code > 255)
+  ) {
+    throw new Error("Scenario shell expectedExitCode must contain valid exit codes.");
+  }
+  return codes;
+}
+
+export function createScenarioShell(definition: ScenarioShellDefinition): ScenarioShell {
+  if (definition.journal && definition.journalPath) {
+    throw new Error("Scenario shell accepts either journal or journalPath, not both.");
+  }
+  if (definition.commands?.length === 0) {
+    throw new Error("Scenario shell requires at least one allowed command.");
+  }
+
+  const journal = definition.journal ?? new ScenarioRuntimeJournal(definition.journalPath);
+  const commands = [...(definition.commands ?? DEFAULT_SCENARIO_SHELL_COMMANDS)];
+  const shell = new Bash({
+    commands,
+    cwd: "/",
+    // just-bash's Node module-loader patches are unavailable in Bun. The
+    // scenario boundary instead keeps host commands, network, JS, and Python
+    // disabled and roots every filesystem capability below the workspace.
+    defenseInDepth: process.versions.bun ? false : { enabled: "auto" },
+    env: {
+      HOME: "/",
+      LANG: "C",
+      LC_ALL: "C",
+      TZ: "UTC",
+      ...definition.env
+    },
+    executionLimitProfile: "hardened",
+    executionLimits: {
+      ...DEFAULT_EXECUTION_LIMITS,
+      ...definition.executionLimits
+    },
+    fs: new ReadWriteFs({
+      root: definition.workspaceDirectory,
+      allowSymlinks: false,
+      maxCopyOnWriteSize: 16 * 1024 * 1024,
+      maxCopySize: 16 * 1024 * 1024,
+      maxFileReadSize: 16 * 1024 * 1024
+    }),
+    javascript: false,
+    python: false
+  });
+  journal.record("shell.create", { commands, workspaceDirectory: definition.workspaceDirectory });
+
+  return {
+    journal,
+    async exec(command: string, options: ScenarioShellExecOptions = {}): Promise<ScenarioShellResult> {
+      const expected = expectedExitCodes(options.expectedExitCode);
+      journal.record("shell.start", {
+        command,
+        cwd: options.cwd ?? "/",
+        expectedExitCodes: expected,
+        stdinBytes: Buffer.byteLength(options.stdin ?? "")
+      });
+      try {
+        const result = await shell.exec(command, {
+          cwd: options.cwd ?? "/",
+          env: options.env ? { ...options.env } : undefined,
+          signal: options.signal,
+          stdin: options.stdin
+        });
+        const publicResult = {
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+          stdout: result.stdout
+        };
+        journal.record("shell.finish", {
+          exitCode: result.exitCode,
+          stderr: journalText(result.stderr),
+          stdout: journalText(result.stdout)
+        });
+        if (!expected.includes(result.exitCode)) {
+          throw new Error(
+            `Scenario shell expected exit ${expected.join(" or ")}, received ${result.exitCode}: ${result.stderr.trim()}`
+          );
+        }
+        return publicResult;
+      } catch (error) {
+        journal.record("shell.error", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+        throw error;
+      }
+    }
+  };
+}

--- a/test/tui/scenario-mountx.test.ts
+++ b/test/tui/scenario-mountx.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+
+import {
+  MountxWorkspaceBackend,
+  probeScenarioMountx
+} from "./harness/mountx-workspace-backend.ts";
+import { ScenarioWorkspace } from "./harness/scenario-workspace.ts";
+
+test("Mountx reports whether this host has an explicit workspace transport", async () => {
+  const probe = await probeScenarioMountx();
+
+  expect(probe.platform).toBe(process.platform);
+  expect(probe.preference.length).toBeGreaterThan(0);
+  if (probe.chosen) {
+    expect(probe[probe.chosen].usable).toBe(true);
+  } else {
+    expect(probe.reason).toBeTruthy();
+  }
+});
+
+test.skipIf(process.env.ZCODE_TEST_MOUNTX !== "1")(
+  "Mountx memory workspace supports real filesystem and Git processes",
+  async () => {
+    await using workspace = await ScenarioWorkspace.create({
+      backend: new MountxWorkspaceBackend(),
+      files: { "README.md": "mounted baseline\n" }
+    });
+
+    await workspace.write("mounted.txt", "mounted write\n");
+    expect(await workspace.read("mounted.txt")).toBe("mounted write\n");
+    expect((await workspace.git(["status", "--short"])).stdout).toContain("?? mounted.txt");
+  },
+  30_000
+);

--- a/test/tui/scenario-shell.test.ts
+++ b/test/tui/scenario-shell.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+
+import { ScenarioWorkspace } from "./harness/scenario-workspace.ts";
+import { createScenarioShell } from "./runtime/scenario-shell.ts";
+
+test("scenario shell writes through the isolated workspace and real Git sees the result", async () => {
+  await using workspace = await ScenarioWorkspace.create({
+    files: { "input.txt": "beta\nalpha\n" }
+  });
+  const shell = createScenarioShell({
+    journalPath: workspace.runtimeJournalPath,
+    workspaceDirectory: workspace.directory
+  });
+
+  const result = await shell.exec(
+    "mkdir -p reports && sort input.txt | tee reports/sorted.txt | wc -l"
+  );
+
+  expect(result).toMatchObject({ exitCode: 0, stderr: "", stdout: "2\n" });
+  expect(await workspace.read("reports/sorted.txt")).toBe("alpha\nbeta\n");
+  expect((await workspace.git(["status", "--short"])).stdout).toContain("?? reports/");
+  expect(await workspace.readRuntimeJournal()).toContain('"kind":"shell.finish"');
+});
+
+test("scenario shell exposes only allowlisted commands without host or network access", async () => {
+  await using workspace = await ScenarioWorkspace.create();
+  const shell = createScenarioShell({ workspaceDirectory: workspace.directory });
+
+  await expect(shell.exec("git status")).rejects.toThrow("received 127");
+  await expect(shell.exec("curl https://example.com")).rejects.toThrow("received 127");
+  const outside = await shell.exec("cat /etc/passwd", { expectedExitCode: 1 });
+  expect(outside.stderr).toContain("No such file");
+});
+
+test("scenario shell supports expected failures, cancellation, and bounded execution", async () => {
+  await using workspace = await ScenarioWorkspace.create();
+  const shell = createScenarioShell({
+    executionLimits: {
+      maxExecutionTimeMs: 50,
+      maxLoopIterations: 20
+    },
+    workspaceDirectory: workspace.directory
+  });
+
+  await expect(shell.exec("while true; do echo loop >/dev/null; done")).rejects.toThrow();
+
+  const controller = new AbortController();
+  controller.abort(new Error("scenario cancelled"));
+  await expect(shell.exec("echo unreachable", {
+    signal: controller.signal
+  })).rejects.toThrow();
+});
+
+test("scenario shell rejects ambiguous journals and invalid exit expectations", async () => {
+  await using workspace = await ScenarioWorkspace.create();
+  const journalPath = workspace.runtimeJournalPath;
+  expect(() => createScenarioShell({
+    journal: createScenarioShell({
+      workspaceDirectory: workspace.directory
+    }).journal,
+    journalPath,
+    workspaceDirectory: workspace.directory
+  })).toThrow("either journal or journalPath");
+
+  const shell = createScenarioShell({ workspaceDirectory: workspace.directory });
+  await expect(shell.exec("true", { expectedExitCode: [] })).rejects.toThrow(
+    "must contain valid exit codes"
+  );
+});

--- a/test/tui/scenario-workspace.test.ts
+++ b/test/tui/scenario-workspace.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test";
 
 import { readWorkspaceDiff } from "../../packages/zcode-tui/src/workspace-diff.ts";
-import { ScenarioWorkspace } from "./harness/scenario-workspace.ts";
+import {
+  ScenarioWorkspace,
+  type ScenarioWorkspaceBackend
+} from "./harness/scenario-workspace.ts";
 
 test.skipIf(process.platform === "win32")("scenario workspace exposes real writes to Git and resets them", async () => {
   await using workspace = await ScenarioWorkspace.create({
@@ -30,4 +33,25 @@ test.skipIf(process.platform === "win32")("scenario workspace exposes real write
 test("scenario workspace rejects paths outside its isolated root", async () => {
   await using workspace = await ScenarioWorkspace.create();
   await expect(workspace.write("../escaped.txt", "not allowed\n")).rejects.toThrow("escapes the workspace");
+});
+
+test("scenario workspace mounts and disposes an optional backend exactly once", async () => {
+  let mountedDirectory = "";
+  let disposeCalls = 0;
+  const backend: ScenarioWorkspaceBackend = {
+    name: "fixture-backend",
+    async mount(directory) {
+      mountedDirectory = directory;
+    },
+    async dispose() {
+      disposeCalls += 1;
+    }
+  };
+  const workspace = await ScenarioWorkspace.create({ backend });
+
+  expect(mountedDirectory).toBe(workspace.directory);
+  expect(workspace.backendName).toBe("fixture-backend");
+  await workspace.dispose();
+  await workspace.dispose();
+  expect(disposeCalls).toBe(1);
 });

--- a/test/tui/scenarios/allowlisted-shell.ts
+++ b/test/tui/scenarios/allowlisted-shell.ts
@@ -1,0 +1,43 @@
+import { join } from "node:path";
+
+import type { TuiScenario } from "./types.ts";
+
+export const allowlistedShellScenario: TuiScenario = {
+  name: "allowlisted-shell",
+  description: "Runs an allowlisted just-bash command and renders its real Git diff.",
+  fixture: join(import.meta.dir, "..", "fixtures", "allowlisted-shell.ts"),
+  files: {
+    "reports/shell.txt": "before\n"
+  },
+  async run(session, workspace) {
+    await session.waitForScreen(
+      "scenario instructions",
+      /Type “run allowlisted shell” to execute a bounded just-bash command/iu,
+      20_000
+    );
+    session.send("run allowlisted shell\r");
+    await session.waitForScreen("shell permission", /ALLOWLISTED_SHELL_WRITE/iu);
+    await session.sendAndWait(
+      "\r",
+      "shell completion",
+      /Allowlisted shell complete: 2 lines\./iu
+    );
+    if (await workspace.read("reports/shell.txt") !== "alpha\nbeta\n") {
+      throw new Error("The allowlisted shell did not write the expected workspace file.");
+    }
+    await session.sendAndWait(
+      "/diff\r",
+      "diff source picker",
+      /Select current workspace changes or a completed turn\./iu
+    );
+    await session.sendAndWait(
+      "\r",
+      "allowlisted shell diff",
+      /reports\/shell\.txt/iu
+    );
+    session.send("\x1b");
+    await session.settle();
+    session.send("\x1b");
+    await session.settle();
+  }
+};

--- a/test/tui/scenarios/index.ts
+++ b/test/tui/scenarios/index.ts
@@ -1,9 +1,11 @@
+import { allowlistedShellScenario } from "./allowlisted-shell.ts";
 import { httpMockScenario } from "./http-mock.ts";
 import { permissionRequestQueueScenario } from "./permission-request-queue.ts";
 import type { TuiScenario } from "./types.ts";
 import { writeAndDiffScenario } from "./write-and-diff.ts";
 
 const scenarios = new Map<string, TuiScenario>([
+  [allowlistedShellScenario.name, allowlistedShellScenario],
   [httpMockScenario.name, httpMockScenario],
   [permissionRequestQueueScenario.name, permissionRequestQueueScenario],
   [writeAndDiffScenario.name, writeAndDiffScenario]


### PR DESCRIPTION
## Summary

- add a bounded, allowlisted just-bash backend rooted at the isolated scenario workspace
- keep host commands, network, JavaScript, Python, and native Git outside the shell boundary
- add an automatic/manual TUI scenario covering Bash permission approval, shell writes, and production Git diff rendering
- make `ScenarioWorkspace` support optional mount/dispose backends
- add an opt-in Mountx kernel-mounted memory workspace with transport probing and custom-driver support
- add `--workspace-backend=mountx` to the scenario runner
- document the completed runtime, HTTP, shell, disk, Mountx, Git, and container/VM boundaries

## Test plan

- `bun run typecheck`
- `bun run test:tui-scenario --list`
- `bun test test/tui/scenario-shell.test.ts test/tui/scenario-mountx.test.ts test/tui/allowlisted-shell.test.ts`
- `TMPDIR=/tmp bun run test:all`
- `bun run build`
- `git diff --check`
- `ZCODE_TEST_MOUNTX=1 bun test test/tui/scenario-mountx.test.ts`

## Results

- Fast: 647 passed
- TUI: 27 passed, 1 opt-in Mountx test skipped in the default run
- Runtime: 13 passed
- Explicit Mountx NFS integration: 2 passed, 0 failed
- No residual NFS mounts after integration cleanup